### PR TITLE
Auth with username and password, not token.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ registries:
     artifactory:
         type: npm-registry
         url: https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/
-        token: ${{ secrets.ARTIFACTORY_NPM_AUTH }}
+        username: ${{ secrets.ARTIFACTORY_NPM_EMAIL}}
+        password: ${{ secrets.ARTIFACTORY_NPM_AUTH }}
 updates:
     - package-ecosystem: npm
       directory: /


### PR DESCRIPTION
Dependabot encountered an auth error (https://github.com/mongodb/devcenter/network/updates/271285672). There is an option to use `username` and `password` rather than just a token, so I'm trying that instead.