### PR TITLE
[DEVHUB-1048] Callout component and sticky Table of Contents

### DIFF
--- a/src/components/article-body/body-components/callout.tsx
+++ b/src/components/article-body/body-components/callout.tsx
@@ -93,13 +93,13 @@ export const Callout: React.FunctionComponent<CalloutProps> = ({
             <div sx={iconStyles(colorMedium)}>
                 <SystemIcon
                     sx={{ display: ['none', null, null, 'block'] }}
-                    name={ESystemIconNames.CIRCLE_ALERT}
+                    name={ESystemIconNames.CIRCLE_INFO}
                     size="medium"
                     inheritColor
                 />
                 <SystemIcon
                     sx={{ display: ['block', null, null, 'none'] }}
-                    name={ESystemIconNames.CIRCLE_ALERT}
+                    name={ESystemIconNames.CIRCLE_INFO}
                     size="small"
                     inheritColor
                 />

--- a/src/components/article-body/body-components/callout.tsx
+++ b/src/components/article-body/body-components/callout.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import {
+    SystemIcon,
+    ESystemIconNames,
+    TypographyScale,
+    VerticalSectionSpacing,
+} from '@mdb/flora';
+import theme from '@mdb/flora/theme';
+import { ComponentFactory } from '../component-factory';
+import { ThemeUIStyleObject } from 'theme-ui';
+import { ArticleNode } from '../../../interfaces/article-body-node';
+
+type TVariant = 'generic' | 'note' | 'important';
+
+interface CalloutProps {
+    variant?: TVariant;
+    children: ArticleNode[];
+}
+
+const baseCardStyles = {
+    boxShadow: 'level01',
+    border: `1px solid ${theme.colors.card.default.border}`,
+    borderBottomRightRadius: 'inc40',
+    borderTopRightRadius: 'inc40',
+    borderLeftWidth: '3px',
+};
+
+const iconStyles = (cardColor: string): ThemeUIStyleObject => ({
+    position: 'relative',
+    top: [
+        `calc(${theme.sizes.inc20} / 2)`,
+        null,
+        null,
+        `calc(${theme.sizes.inc40} / 2)`,
+    ],
+    right: [
+        `calc(${theme.sizes.inc20} / 2)`,
+        null,
+        null,
+        `calc(${theme.sizes.inc40} / 2)`,
+    ],
+    height: ['inc20', null, null, 'inc40'],
+    width: ['inc20', null, null, 'inc40'],
+
+    bg: 'black00',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    stroke: cardColor,
+    borderRadius: 'circle',
+});
+
+const variantCardColor = (variant: TVariant) => {
+    let colorMedium;
+    let colorLight;
+    let colorDark;
+    switch (variant) {
+        case 'generic':
+            colorMedium = 'purple60';
+            break;
+        case 'note':
+            colorDark = 'blue70';
+            colorMedium = 'blue60';
+            colorLight = 'blue10';
+            break;
+        case 'important':
+            colorDark = 'yellow70';
+            colorMedium = 'yellow40';
+            colorLight = 'yellow10';
+            break;
+    }
+    return { colorDark, colorMedium, colorLight };
+};
+
+export const Callout: React.FunctionComponent<CalloutProps> = ({
+    variant = 'generic',
+    children,
+    ...rest
+}) => {
+    console.log(children);
+    const { colorDark, colorMedium, colorLight } = variantCardColor(variant);
+    return (
+        <div
+            sx={{
+                marginTop: [
+                    `calc(-${theme.sizes.inc20} / 2)`,
+                    null,
+                    null,
+                    `calc(-${theme.sizes.inc40} / 2)`,
+                ],
+            }}
+        >
+            <div sx={iconStyles(colorMedium)}>
+                <SystemIcon
+                    sx={{ display: ['none', null, null, 'block'] }}
+                    name={ESystemIconNames.CIRCLE_ALERT}
+                    size="medium"
+                    inheritColor
+                />
+                <SystemIcon
+                    sx={{ display: ['block', null, null, 'none'] }}
+                    name={ESystemIconNames.CIRCLE_ALERT}
+                    size="small"
+                    inheritColor
+                />
+            </div>
+            <div
+                sx={{
+                    ...baseCardStyles,
+                    borderLeftColor: colorMedium,
+                }}
+            >
+                {variant !== 'generic' && (
+                    <div
+                        sx={{
+                            bg: colorLight,
+                            px: 'inc40',
+                            py: ['inc20', null, null, 'inc30'],
+                            borderTopRightRadius: 'inc40',
+                        }}
+                    >
+                        <TypographyScale
+                            variant="body1"
+                            sx={{ color: colorDark }}
+                        >
+                            {variant === 'important' ? 'Important' : 'Note'}
+                        </TypographyScale>
+                    </div>
+                )}
+
+                <div sx={{ px: 'inc40', py: 'inc30' }}>
+                    {children.map((element, index) => (
+                        <VerticalSectionSpacing
+                            key={index}
+                            top={index === 0 ? 'zero' : 'xxsmall'}
+                            bottom={
+                                index === children.length - 1
+                                    ? 'zero'
+                                    : 'xxsmall'
+                            }
+                        >
+                            <ComponentFactory
+                                {...rest}
+                                nodeData={element}
+                                key={index}
+                            />
+                        </VerticalSectionSpacing>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/article-body/body-components/callout.tsx
+++ b/src/components/article-body/body-components/callout.tsx
@@ -77,7 +77,6 @@ export const Callout: React.FunctionComponent<CalloutProps> = ({
     children,
     ...rest
 }) => {
-    console.log(children);
     const { colorDark, colorMedium, colorLight } = variantCardColor(variant);
     return (
         <div

--- a/src/components/article-body/component-factory.tsx
+++ b/src/components/article-body/component-factory.tsx
@@ -19,6 +19,7 @@ import { TableCell } from './body-components/table-cell';
 import { ArticleImage } from './body-components/image';
 import { Figure } from './body-components/figure';
 import { CodeTabs } from './body-components/codepanel';
+import { Callout } from './body-components/callout';
 
 const componentMap: { [key: string]: any } = {
     paragraph: Paragraph,
@@ -42,6 +43,7 @@ const componentMap: { [key: string]: any } = {
     image: ArticleImage,
     figure: Figure,
     tabs: CodeTabs,
+    blockquote: Callout,
 };
 export const ComponentFactory = ({
     nodeData,

--- a/src/components/article-body/table-of-contents.tsx
+++ b/src/components/article-body/table-of-contents.tsx
@@ -39,12 +39,13 @@ const formatText = (text: string | any) => {
 
 export const TableOfContents = ({
     headingNodes,
-    ...props
+    className,
 }: {
     headingNodes: any;
+    className?: string;
 }) => {
     return (
-        <div sx={{ paddingLeft: 'inc70' }}>
+        <div sx={{ paddingLeft: 'inc70' }} className={className}>
             <TypographyScale variant="heading6">
                 Table of Contents
             </TypographyScale>

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -54,7 +54,6 @@ const sideNavStyles = {
 };
 
 const imageStyles = {
-    marginTop: 'inc40',
     marginBottom: ['inc20', null, null, 'inc30'],
     aspectRatio: '16/9',
     position: 'relative' as 'relative',
@@ -131,7 +130,9 @@ const ContentPage: NextPage<ContentPiece> = ({
     const contentHeader = (
         <>
             <div sx={middleSectionStyles}>
-                <Eyebrow sx={{ marginBottom: 'inc30' }}>{category}</Eyebrow>
+                <Eyebrow sx={{ marginBottom: ['inc20', null, null, 'inc30'] }}>
+                    {category}
+                </Eyebrow>
                 <TypographyScale
                     variant="heading2"
                     sx={{
@@ -140,26 +141,28 @@ const ContentPage: NextPage<ContentPiece> = ({
                 >
                     {title}
                 </TypographyScale>
-                {!vidOrPod ? (
-                    <div sx={socialFlexContainerStyles}>
-                        <SpeakerLockup
-                            name={authors?.join(',')}
-                            title={`${contentDate}`}
-                        />
-                        {SocialButtons}
-                    </div>
-                ) : (
-                    <TypographyScale
-                        variant="body3"
-                        color="secondary"
-                        customStyles={{
-                            display: 'block',
-                            marginBottom: 'inc30',
-                        }}
-                    >
-                        {contentDate}
-                    </TypographyScale>
-                )}
+                <div sx={{ marginBottom: ['inc30', null, null, 'inc40'] }}>
+                    {!vidOrPod ? (
+                        <div sx={socialFlexContainerStyles}>
+                            <SpeakerLockup
+                                name={authors?.join(',')}
+                                title={`${contentDate}`}
+                            />
+                            {SocialButtons}
+                        </div>
+                    ) : (
+                        <TypographyScale
+                            variant="body3"
+                            color="secondary"
+                            customStyles={{
+                                display: 'block',
+                                marginBottom: 'inc30',
+                            }}
+                        >
+                            {contentDate}
+                        </TypographyScale>
+                    )}
+                </div>
                 {tags && (
                     <div sx={socialFlexContainerStyles}>
                         <TagSection tags={tags} />

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -50,6 +50,7 @@ const sideNavStyles = {
     nav: {
         position: 'static' as 'static',
     },
+    gridRow: 'span 4',
 };
 
 const imageStyles = {
@@ -64,6 +65,10 @@ const socialFlexContainerStyles = {
     justifyContent: 'space-between',
     alignItems: 'end',
     marginBottom: ['inc30', null, null, 'inc40'],
+};
+
+const middleSectionStyles = {
+    gridColumn: ['span 6', null, 'span 8', 'span 12', '4 /span 6'],
 };
 
 const ContentPage: NextPage<ContentPiece> = ({
@@ -125,7 +130,7 @@ const ContentPage: NextPage<ContentPiece> = ({
 
     const contentHeader = (
         <>
-            <div>
+            <div sx={middleSectionStyles}>
                 <Eyebrow sx={{ marginBottom: 'inc30' }}>{category}</Eyebrow>
                 <TypographyScale
                     variant="heading2"
@@ -163,7 +168,7 @@ const ContentPage: NextPage<ContentPiece> = ({
                 )}
             </div>
 
-            <div>
+            <div sx={middleSectionStyles}>
                 <div sx={imageStyles}>
                     <Image
                         alt="alt"
@@ -182,7 +187,12 @@ const ContentPage: NextPage<ContentPiece> = ({
     );
 
     const contentBody = (
-        <>
+        <div
+            sx={{
+                ...middleSectionStyles,
+                my: ['section20', null, 'section30', 'section40'],
+            }}
+        >
             {vidOrPod && (
                 <TypographyScale
                     variant="body1"
@@ -196,15 +206,14 @@ const ContentPage: NextPage<ContentPiece> = ({
             {vidOrPod && (
                 <CTALink
                     customCSS={{
-                        marginTop: '24px',
-                        marginBottom: '48px',
+                        marginTop: 'inc40',
                     }}
                     text="All MongoDB Videos"
                     url="#"
                 />
             )}
             {!vidOrPod && <DocumentBody content={contentAst} />}
-        </>
+        </div>
     );
 
     const contentFooter = (
@@ -213,6 +222,7 @@ const ContentPage: NextPage<ContentPiece> = ({
                 display: 'flex',
                 flexDirection: 'column',
                 gap: ['section30', null, 'section40', 'section50'],
+                ...middleSectionStyles,
             }}
         >
             <div>
@@ -267,37 +277,29 @@ const ContentPage: NextPage<ContentPiece> = ({
             >
                 <GridLayout
                     sx={{
-                        rowGap: ['inc90', null, null, 'inc130'],
+                        rowGap: 0,
                     }}
                 >
                     <div sx={sideNavStyles}>
                         <SideNav currentUrl="#" items={tertiaryNavItems} />
                     </div>
 
-                    <div
-                        sx={{
-                            gridColumn: [
-                                'span 6',
-                                null,
-                                'span 8',
-                                'span 12',
-                                '4 /span 6',
-                            ],
-                        }}
-                    >
-                        {contentHeader}
-                        {contentBody}
-                        {contentFooter}
-                    </div>
+                    {contentHeader}
+                    {contentBody}
+                    {contentFooter}
                     {!vidOrPod && (
                         <div
                             sx={{
                                 display: ['none', null, null, null, 'block'],
                                 gridColumn: '10 /span 3',
+                                gridRow: '2 /4',
                             }}
                         >
                             {headingNodes.length > 0 && (
-                                <TableOfContents headingNodes={headingNodes} />
+                                <TableOfContents
+                                    headingNodes={headingNodes}
+                                    sx={{ position: 'sticky', top: 'inc150' }}
+                                />
                             )}
                         </div>
                     )}


### PR DESCRIPTION
[Jira Ticket](https://jira.mongodb.org/browse/DEVHUB-1048)

Callout component (maps to blockquote). There are variants for `generic`, `note`, and `important` in the designs, and all current blockquotes will be the `generic` version. Not sure how people will choose between these variants, but I built out support for them anyway. The icons in the designs are not all available in flora, so I put a placeholder in there and will add those to flora.

I also aligned the table of contents to the image on the articles and made it sticky.