### PR TITLE
Authors API call- for Author type pages

### DIFF
--- a/src/api-requests/get-authors.ts
+++ b/src/api-requests/get-authors.ts
@@ -1,0 +1,40 @@
+import { Author } from '../interfaces/author';
+import { UnderlyingClient } from '../types/client-factory';
+import { ApolloQueryResult, gql } from '@apollo/client';
+
+export const getAllAuthorsFromAPI = async (
+    client: UnderlyingClient<'ApolloREST'>
+): Promise<Author[]> => {
+    const query = gql`
+        query Authors {
+            authors @rest(type: "Authors", path: "/authors") {
+                name
+                bio
+                image {
+                    url
+                }
+                location
+                linkedin
+                facebook
+                twitter
+                youtube
+                calculated_slug
+                articles: new_articles {
+                    name
+                    calculated_slug
+                    description
+                    otherTags: other_tags(first: 1) {
+                        contentType: content_type(first: 1) {
+                            contentType: content_type
+                            calculatedSlug: calculated_slug
+                        }
+                    }
+                }
+            }
+        }
+    `;
+    const { data }: ApolloQueryResult<{ authors: Author[] }> =
+        await client.query({ query });
+
+    return data.authors;
+};

--- a/src/components/author-lockup/types.ts
+++ b/src/components/author-lockup/types.ts
@@ -1,4 +1,4 @@
-export interface Author {
+export interface AuthorLockUp {
     name: string;
     image?: {
         src?: string;
@@ -8,7 +8,7 @@ export interface Author {
 }
 export interface AuthorLockupProps {
     className?: string;
-    authors: Author[];
+    authors: AuthorLockUp[];
     title?: string;
     expandedNames?: boolean;
     clickableLinks?: boolean;
@@ -16,7 +16,7 @@ export interface AuthorLockupProps {
 }
 
 export interface AuthorImageProps {
-    author: Author;
+    author: AuthorLockUp;
     className?: string;
     size: 'small' | 'large';
 }

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -23,6 +23,7 @@ import TagSection from '../tag-section';
 import { CardProps } from './types';
 import parse from 'html-react-parser';
 import { formatDateToDisplayDateFormat } from '../../utils/format-date';
+import { parseAuthorsToAuthorLockup } from '../../utils/parse-authors-to-author-lockup';
 
 // Still need to add authors section.
 const Card: React.FunctionComponent<CardProps> = ({
@@ -103,16 +104,7 @@ const Card: React.FunctionComponent<CardProps> = ({
                         {authors && hasAuthorLockup(variant, pillCategory) && (
                             <AuthorLockup
                                 sx={{ display: ['none', null, 'flex'] }}
-                                authors={[
-                                    { name: 'Some Person', url: '#' },
-                                    {
-                                        name: 'Other Person',
-                                        image: {
-                                            src: 'https://mongodb-devhub-cms.s3.us-west-1.amazonaws.com/ATF_720x720_17fd9d891f.png',
-                                        },
-                                        url: '#',
-                                    },
-                                ]}
+                                authors={parseAuthorsToAuthorLockup(authors)}
                             />
                         )}
                         <TypographyScale variant="body3">

--- a/src/components/card/types.ts
+++ b/src/components/card/types.ts
@@ -1,5 +1,6 @@
 import { PillCategory } from '../../types/pill-category';
 import { Tag } from '../../interfaces/tag';
+import { Author } from '../../interfaces/author';
 
 export interface Thumbnail {
     url: string;
@@ -9,7 +10,7 @@ export interface Thumbnail {
 export type CardVariant = 'small' | 'medium' | 'large' | 'list' | 'related';
 
 export interface CardProps {
-    authors?: string[];
+    authors?: Author[];
     contentDate: string;
     className?: string;
     description?: string;

--- a/src/interfaces/author.ts
+++ b/src/interfaces/author.ts
@@ -1,9 +1,25 @@
+import { OtherTags } from './other-tags';
+
 type Image = {
     url: string;
 };
 
+type ArticlesByAuthor = {
+    name: string;
+    calculated_slug: string;
+    description: string;
+    otherTags: OtherTags[];
+};
+
 export interface Author {
     name: string;
-    bio: string;
-    image: Image;
+    bio?: string;
+    image?: Image;
+    location?: string;
+    linkedin?: string;
+    facebook?: string;
+    twitter?: string;
+    youtube?: string;
+    articles?: ArticlesByAuthor[];
+    calculated_slug: string;
 }

--- a/src/interfaces/content-item.ts
+++ b/src/interfaces/content-item.ts
@@ -2,9 +2,10 @@ import { PillCategory } from '../types/pill-category';
 import { Series } from './series';
 import { Tag } from './tag';
 import { Image } from './image';
+import { Author } from './author';
 
 export interface ContentItem {
-    authors?: string[];
+    authors?: Author[];
     category: PillCategory;
     contentDate: string;
     updateDate?: string;

--- a/src/mockdata/get-l1-content.ts
+++ b/src/mockdata/get-l1-content.ts
@@ -8,7 +8,12 @@ interface L1Content {
 const getL1Content = (slug: string = 'all'): L1Content => {
     const featured: ContentItem[] = [
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Article',
             image: {
                 alt: 'thumbnail',
@@ -23,7 +28,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/a1',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Video',
             image: {
                 alt: 'thumbnail',
@@ -41,7 +51,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
         },
 
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Tutorial',
             image: {
                 alt: 'thumbnail',
@@ -58,7 +73,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
     ];
     const content: ContentItem[] = [
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Demo App',
             image: {
                 alt: 'thumbnail',
@@ -73,7 +93,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/d1',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Demo App',
             image: {
                 alt: 'thumbnail',
@@ -88,7 +113,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/d2',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Demo App',
             image: {
                 alt: 'thumbnail',
@@ -103,7 +133,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/d3',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Video',
             image: {
                 alt: 'thumbnail',
@@ -120,7 +155,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/v1',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Video',
             image: {
                 alt: 'thumbnail',
@@ -137,7 +177,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/v2',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Video',
             image: {
                 alt: 'thumbnail',
@@ -154,7 +199,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/v3',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Article',
             title: 'This is 101 article',
             description:
@@ -165,7 +215,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/a1',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Article',
             image: {
                 alt: 'thumbnail',
@@ -179,7 +234,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/a2',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Article',
             image: {
                 alt: 'thumbnail',
@@ -193,7 +253,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/a3',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Article',
             image: {
                 alt: 'thumbnail',
@@ -207,7 +272,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/a4',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Tutorial',
             image: {
                 alt: 'thumbnail',
@@ -222,7 +292,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/t1',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Tutorial',
             image: {
                 alt: 'thumbnail',
@@ -237,7 +312,12 @@ const getL1Content = (slug: string = 'all'): L1Content => {
             slug: 'product/atlas/t2',
         },
         {
-            authors: ['Farah Appleseed'],
+            authors: [
+                {
+                    name: 'Farah Appleseed',
+                    calculated_slug: '/author/farah-appleseed',
+                },
+            ],
             category: 'Tutorial',
             image: {
                 alt: 'thumbnail',

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -185,19 +185,7 @@ const ContentPage: NextPage<ContentPageProps> = ({
         -1
     );
 
-    //TODO replace with authors
     const authorsToDisplay = parseAuthorsToAuthorLockup(authors);
-
-    //     [
-    //     { name: 'Some Person', url: '#' },
-    //     {
-    //         name: 'Other Person',
-    //         image: {
-    //             src: 'https://mongodb-devhub-cms.s3.us-west-1.amazonaws.com/ATF_720x720_17fd9d891f.png',
-    //         },
-    //         url: '#',
-    //     },
-    // ];
 
     const ratingSection = (
         <div

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -40,10 +40,10 @@ import parse from 'html-react-parser';
 import { PillCategory } from '../types/pill-category';
 import { getSideNav } from '../service/get-side-nav';
 import { TertiaryNavItem } from '../components/tertiary-nav/types';
-import Script from 'next/script';
 import { VideoEmbed } from '../components/article-body/body-components/video-embed';
 import { getPlaceHolderImage } from '../utils/get-place-holder-thumbnail';
 import PodcastPlayer from '../components/podcast-player/podcast-player';
+import { parseAuthorsToAuthorLockup } from '../utils/parse-authors-to-author-lockup';
 
 interface ContentPageProps {
     contentItem: ContentItem;
@@ -186,16 +186,18 @@ const ContentPage: NextPage<ContentPageProps> = ({
     );
 
     //TODO replace with authors
-    const authorsToDisplay = [
-        { name: 'Some Person', url: '#' },
-        {
-            name: 'Other Person',
-            image: {
-                src: 'https://mongodb-devhub-cms.s3.us-west-1.amazonaws.com/ATF_720x720_17fd9d891f.png',
-            },
-            url: '#',
-        },
-    ];
+    const authorsToDisplay = parseAuthorsToAuthorLockup(authors);
+
+    //     [
+    //     { name: 'Some Person', url: '#' },
+    //     {
+    //         name: 'Other Person',
+    //         image: {
+    //             src: 'https://mongodb-devhub-cms.s3.us-west-1.amazonaws.com/ATF_720x720_17fd9d891f.png',
+    //         },
+    //         url: '#',
+    //     },
+    // ];
 
     const ratingSection = (
         <div

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import { GetStaticProps } from 'next';
 import { clientFactory } from '../utils/client-factory';
 import { getArticles } from '../api-requests/get-articles';
 import { Article } from '../interfaces/article';
+import { getAllAuthors } from '../service/get-all-authors';
 
 interface HomeProps {
     articles: Article[];
@@ -28,6 +29,7 @@ export default Home;
 export const getStaticProps: GetStaticProps = async ({}) => {
     const client = clientFactory('ApolloREST', process.env.STRAPI_URL);
     const articles = await getArticles(client);
+    const authors = await getAllAuthors();
     return {
         props: { articles },
     };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,6 @@ import { GetStaticProps } from 'next';
 import { clientFactory } from '../utils/client-factory';
 import { getArticles } from '../api-requests/get-articles';
 import { Article } from '../interfaces/article';
-import { getAllAuthors } from '../service/get-all-authors';
 
 interface HomeProps {
     articles: Article[];
@@ -29,7 +28,6 @@ export default Home;
 export const getStaticProps: GetStaticProps = async ({}) => {
     const client = clientFactory('ApolloREST', process.env.STRAPI_URL);
     const articles = await getArticles(client);
-    const authors = await getAllAuthors();
     return {
         props: { articles },
     };

--- a/src/service/get-all-authors.ts
+++ b/src/service/get-all-authors.ts
@@ -1,0 +1,7 @@
+import { STRAPI_CLIENT } from '../config/api-client';
+import { Author } from '../interfaces/author';
+import { getAllAuthorsFromAPI } from '../api-requests/get-authors';
+
+export const getAllAuthors = async (): Promise<Author[]> => {
+    return getAllAuthorsFromAPI(STRAPI_CLIENT);
+};

--- a/src/service/get-all-content.ts
+++ b/src/service/get-all-content.ts
@@ -60,7 +60,7 @@ export const mapPodcastsToContentItems = (
             item.image = { url: p.thumbnailUrl, alt: 'randomAlt' };
         }
         item.podcastFileUrl = p.casted_slug;
-        //addSeriesToItem(item, 'podcast', podcastSeries);
+        addSeriesToItem(item, 'podcast', podcastSeries);
         items.push(item);
     });
     return items;
@@ -91,7 +91,7 @@ export const mapVideosToContentItems = (
         };
 
         item.videoId = v.videoId;
-        //addSeriesToItem(item, 'video', videoSeries);
+        addSeriesToItem(item, 'video', videoSeries);
         items.push(item);
     });
     return items;
@@ -109,7 +109,7 @@ export const mapArticlesToContentItems = (
 
     filteredArticles.forEach((a: Article) => {
         const item: ContentItem = {
-            authors: a.authors.map(author => author.name),
+            authors: a.authors,
             /*
             very important - some times we see content type as video and podcast in article type of data - set their category to 'Article'
              */
@@ -132,7 +132,7 @@ export const mapArticlesToContentItems = (
         if (a.image) {
             item.image = { url: a.image.url, alt: a.image.alt || 'random alt' };
         }
-        //addSeriesToItem(item, 'article', articleSeries);
+        addSeriesToItem(item, 'article', articleSeries);
         items.push(item);
     });
     return items;

--- a/src/utils/parse-authors-to-author-lockup.ts
+++ b/src/utils/parse-authors-to-author-lockup.ts
@@ -1,0 +1,20 @@
+import { Author } from '../interfaces/author';
+import { AuthorLockUp } from '../components/author-lockup/types';
+
+export const parseAuthorsToAuthorLockup = (
+    authors: Author[] | undefined
+): AuthorLockUp[] => {
+    const authorLockup: AuthorLockUp[] = [];
+    if (authors) {
+        authors.forEach(a => {
+            authorLockup.push({
+                name: a.name,
+                image: {
+                    src: a.image?.url,
+                },
+                url: a.calculated_slug,
+            });
+        });
+    }
+    return authorLockup;
+};


### PR DESCRIPTION
This PR addresses two things:

1. Replace Mock authors with real authors
2. Added Graphql call to get all data needed for authors page

https://devcenter-itjrhvjc2-harikakotipalli.vercel.app/product/mongodb/enterprise-operator-kubernetes-openshift
