### PR TITLE
Bugfix adding ExpertiseLevel to L1L2 topic pages

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -5,4 +5,5 @@ export const L1L2_TOPIC_PAGE_TYPES: TagType[] = [
     'L2Product',
     'ProgrammingLanguage',
     'Technology',
+    'ExpertiseLevel',
 ];


### PR DESCRIPTION
Bugfix adding ExpertiseLevel to L1L2 topic pages - since it's there in devhub secondary nav menu.