### PR TITLE
Mc/misc

### DIFF
--- a/src/components/article-body/component-factory.tsx
+++ b/src/components/article-body/component-factory.tsx
@@ -55,6 +55,9 @@ export const ComponentFactory = ({
     parentNode?: any;
 }) => {
     const selectComponent = () => {
+        if (!nodeData) {
+            return null;
+        }
         const { name, type } = nodeData;
         const lookup = type === 'directive' ? name : type;
         let ComponentType = lookup && componentMap[lookup];

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -12,10 +12,13 @@ import {
 } from './styles';
 import { getURLPath } from '../../utils/format-url-path';
 
-const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({ crumbs }) => {
+const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({
+    crumbs,
+    className,
+}) => {
     const crumbLength = crumbs.length;
     return (
-        <div sx={breadcrumbsContainerStyles}>
+        <div sx={breadcrumbsContainerStyles} className={className}>
             {crumbs.map(({ text, url }, i) => (
                 <div key={text} sx={breadcrumbStyles}>
                     <Link navItem={true} href={getURLPath(url)} sx={linkStyles}>

--- a/src/components/breadcrumbs/types.ts
+++ b/src/components/breadcrumbs/types.ts
@@ -4,5 +4,6 @@ export interface Crumb {
 }
 
 export interface BreadcrumbsProps {
+    className?: string;
     crumbs: Crumb[];
 }

--- a/src/components/breadcrumbs/utils.ts
+++ b/src/components/breadcrumbs/utils.ts
@@ -1,0 +1,34 @@
+import { Crumb } from './types';
+import { getMetaInfoForTopic } from '../../service/get-meta-info-for-topic';
+
+const categoryToCrumb: { [key: string]: Crumb } = {
+    products: { text: 'Products', url: '/developer/products' },
+    languages: { text: 'Languages', url: '/developer/languages' },
+    technologies: { text: 'Technologies', url: '/developer/technologies' },
+};
+
+export const getBreadcrumbsFromSlug = async (
+    slug: string
+): Promise<Crumb[]> => {
+    const crumbs: Crumb[] = [
+        { text: 'MongoDB Developer Center', url: '/' },
+        { text: 'Developer Topics', url: '/developer/topics' },
+    ];
+    const slugList = slug.startsWith('/')
+        ? slug.split('/').slice(1)
+        : slug.split('/');
+
+    const categoryCrumb = categoryToCrumb[slugList[0]];
+    if (categoryCrumb) {
+        crumbs.push(categoryCrumb);
+    }
+
+    for (let i = 2; i < slugList.length; i++) {
+        const crumbSlug = '/' + slugList.slice(0, i).join('/');
+        const metaInfoForTopic = await getMetaInfoForTopic(crumbSlug);
+        if (metaInfoForTopic?.tagName) {
+            crumbs.push({ text: metaInfoForTopic.tagName, url: crumbSlug });
+        }
+    }
+    return crumbs;
+};

--- a/src/components/breadcrumbs/utils.ts
+++ b/src/components/breadcrumbs/utils.ts
@@ -2,9 +2,9 @@ import { Crumb } from './types';
 import { getMetaInfoForTopic } from '../../service/get-meta-info-for-topic';
 
 const categoryToCrumb: { [key: string]: Crumb } = {
-    products: { text: 'Products', url: '/developer/products' },
-    languages: { text: 'Languages', url: '/developer/languages' },
-    technologies: { text: 'Technologies', url: '/developer/technologies' },
+    products: { text: 'Products', url: '/products' },
+    languages: { text: 'Languages', url: '/languages' },
+    technologies: { text: 'Technologies', url: '/technologies' },
 };
 
 export const getBreadcrumbsFromSlug = async (
@@ -12,7 +12,7 @@ export const getBreadcrumbsFromSlug = async (
 ): Promise<Crumb[]> => {
     const crumbs: Crumb[] = [
         { text: 'MongoDB Developer Center', url: '/' },
-        { text: 'Developer Topics', url: '/developer/topics' },
+        { text: 'Developer Topics', url: '/topics' },
     ];
     const slugList = slug.startsWith('/')
         ? slug.split('/').slice(1)

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -24,6 +24,8 @@ import parse from 'html-react-parser';
 import { formatDateToDisplayDateFormat } from '../../utils/format-date';
 import { parseAuthorsToAuthorLockup } from '../../utils/parse-authors-to-author-lockup';
 import { getURLPath } from '../../utils/format-url-path';
+import SecondaryTag from './secondary-tag';
+import { CodeLevel } from '../../types/tag-type';
 
 const Card: React.FunctionComponent<CardProps> = ({
     authors,
@@ -38,6 +40,15 @@ const Card: React.FunctionComponent<CardProps> = ({
     slug,
 }) => {
     const displayDate = formatDateToDisplayDateFormat(new Date(contentDate));
+    let secondaryTagElement = null;
+    if (tags && pillCategory === 'Code Example') {
+        const codeLevelTag = tags.find(tag => tag.type === 'CodeLevel');
+        if (codeLevelTag && codeLevelTag.name) {
+            secondaryTagElement = (
+                <SecondaryTag codeLevel={codeLevelTag.name as CodeLevel} />
+            );
+        }
+    }
     return (
         <div
             sx={cardWrapperStyles}
@@ -80,6 +91,7 @@ const Card: React.FunctionComponent<CardProps> = ({
                         text={pillCategory}
                         size="small"
                     />
+                    {secondaryTagElement}
                     <TypographyScale variant="heading6">
                         {title}
                     </TypographyScale>

--- a/src/components/card/secondary-tag.tsx
+++ b/src/components/card/secondary-tag.tsx
@@ -1,0 +1,44 @@
+import theme from '@mdb/flora/theme';
+
+import { FullApplication, Snippet } from '../icons';
+import { CodeLevel } from '../../types/tag-type';
+
+const SecondaryTag: React.FunctionComponent<{ codeLevel: CodeLevel }> = ({
+    codeLevel,
+}) => {
+    return (
+        <div
+            sx={{
+                display: 'flex',
+                alignItems: 'center',
+                color: theme.colors.text.secondary,
+                gap: 'inc10',
+                marginBottom: 'inc30',
+            }}
+        >
+            {codeLevel === 'Snippet' ? (
+                <Snippet
+                    sx={{
+                        strokeWidth: 2,
+                        stroke: theme.colors.text.secondary,
+                    }}
+                />
+            ) : (
+                <FullApplication
+                    sx={{ strokeWidth: 2, fill: theme.colors.text.secondary }}
+                />
+            )}
+            <span
+                sx={{
+                    lineHeight: 'inc00',
+                    fontSize: 'inc00',
+                    fontWeight: '500',
+                }}
+            >
+                {codeLevel.toUpperCase()}
+            </span>
+        </div>
+    );
+};
+
+export default SecondaryTag;

--- a/src/components/icons/BaseIcon.tsx
+++ b/src/components/icons/BaseIcon.tsx
@@ -1,15 +1,17 @@
 export interface BaseIconProps {
     className?: string;
+    isFilled?: boolean;
 }
 
 const BaseIcon: React.FunctionComponent<BaseIconProps> = ({
     className,
     children,
+    isFilled = false,
 }) => {
     return (
         <svg
             viewBox="0 0 24 24"
-            fill="none"
+            {...(isFilled ? {} : { fill: 'none' })}
             xmlns="http://www.w3.org/2000/svg"
             sx={{
                 width: 'inc20',

--- a/src/components/icons/BaseIcon.tsx
+++ b/src/components/icons/BaseIcon.tsx
@@ -11,7 +11,7 @@ const BaseIcon: React.FunctionComponent<BaseIconProps> = ({
     return (
         <svg
             viewBox="0 0 24 24"
-            {...(isFilled ? {} : { fill: 'none' })}
+            {...(!isFilled && { fill: 'none' })}
             xmlns="http://www.w3.org/2000/svg"
             sx={{
                 width: 'inc20',

--- a/src/components/icons/FullApplication.tsx
+++ b/src/components/icons/FullApplication.tsx
@@ -1,0 +1,22 @@
+import BaseIcon, { BaseIconProps } from './BaseIcon';
+
+export const FullApplication: React.FunctionComponent<BaseIconProps> = ({
+    className,
+}) => {
+    return (
+        <BaseIcon className={className}>
+            <path d="M5.5,3c-.8,0-1.5,.7-1.5,1.5s.7,1.5,1.5,1.5,1.5-.7,1.5-1.5-.7-1.5-1.5-1.5h0Z" />
+            <path d="M10.5,3c-.8,0-1.5,.7-1.5,1.5s.7,1.5,1.5,1.5,1.5-.7,1.5-1.5-.7-1.5-1.5-1.5h0Z" />
+            <path
+                fillRule="evenodd"
+                d="M0,3C0,1.3,1.3,0,3,0H19c1.7,0,3,1.3,3,3V19c0,1.7-1.3,3-3,3H3c-1.7,0-3-1.3-3-3V3Zm3-1c-.6,0-1,.4-1,1V7H20V3c0-.6-.4-1-1-1H3Zm17,7H2v10c0,.6,.4,1,1,1H19c.6,0,1-.4,1-1V9Z"
+            />
+            <path
+                fill="none"
+                opacity={0.4}
+                strokeMiterlimit={10}
+                d="M19,21H3c-1.1,0-2-.9-2-2V3c0-1.1,.9-2,2-2h16c1.1,0,2,.9,2,2V19c0,1.1-.9,2-2,2Zm2-13H1"
+            />
+        </BaseIcon>
+    );
+};

--- a/src/components/icons/Snippet.tsx
+++ b/src/components/icons/Snippet.tsx
@@ -1,0 +1,15 @@
+import BaseIcon, { BaseIconProps } from './BaseIcon';
+
+export const Snippet: React.FunctionComponent<BaseIconProps> = ({
+    className,
+}) => {
+    return (
+        <BaseIcon className={className}>
+            <path
+                d="M8.01751 8.00029L4 11.9976L8.00195 16.0105M16.0058 8.01584L20 12.0054L16.0214 16.0105M12.0149 4L12.0227 20"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </BaseIcon>
+    );
+};

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,3 +1,5 @@
 export * from './MenuBoxed';
 export * from './Pin';
 export * from './Alert';
+export * from './FullApplication';
+export * from './Snippet';

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -33,9 +33,11 @@ const Search: React.FunctionComponent<SearchProps> = ({
 
     const { data, error, isValidating } = useSWR(
         () =>
-            `s=${searchString}&contentType=${contentType}&tagSlug=${encodeURIComponent(
-                tagSlug
-            )}`,
+            `s=${encodeURIComponent(
+                searchString
+            )}&contentType=${encodeURIComponent(
+                contentType
+            )}&tagSlug=${encodeURIComponent(tagSlug)}`,
         fetcher,
         {
             revalidateIfStale: false,

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import NextImage from 'next/image';
 import useSWR from 'swr';
-import { Grid } from 'theme-ui';
 
 import {
     Button,
     TextInput,
     ESystemIconNames,
     TypographyScale,
+    Checkbox,
 } from '@mdb/flora';
 
 import { titleStyles, searchBoxStyles, linkStyleOverride } from './styles';
@@ -29,6 +29,8 @@ const Search: React.FunctionComponent<SearchProps> = ({
     const [searchString, setSearchString] = useState('');
     const [resultsToShow, setResultsToShow] = useState(10);
 
+    const [codeLevelFilters, setCodeLevelFilters] = useState<string[]>([]);
+
     const { data, error, isValidating } = useSWR(
         () =>
             `s=${searchString}&contentType=${contentType}&tagSlug=${encodeURIComponent(
@@ -48,8 +50,28 @@ const Search: React.FunctionComponent<SearchProps> = ({
         setSearchString(event.target.value);
     };
 
+    const onCheckToggle = (checked: boolean, filter: string) => {
+        if (checked) {
+            setCodeLevelFilters([...codeLevelFilters, filter]);
+        } else {
+            setCodeLevelFilters(
+                codeLevelFilters.filter(filt => filt !== filter)
+            );
+        }
+    };
+
     const resultsData = data || [];
-    const numberOfResults = resultsData.length;
+    const filteredResultsData =
+        contentType === 'Code Example' && !!codeLevelFilters.length
+            ? resultsData.filter(item =>
+                  item.tags.find(
+                      tag =>
+                          tag.type === 'CodeLevel' &&
+                          codeLevelFilters.includes(tag.name)
+                  )
+              )
+            : resultsData;
+    const numberOfResults = filteredResultsData.length;
     const shownData = resultsData.slice(0, resultsToShow);
     const fullyLoaded = resultsToShow >= numberOfResults;
 
@@ -69,6 +91,10 @@ const Search: React.FunctionComponent<SearchProps> = ({
         </div>
     );
 
+    // To compensate for the Code Level filters.
+    const extraSearchBoxStyles =
+        contentType === 'Code Example' ? { marginBottom: 0 } : {};
+
     return (
         <form role="search" className={className}>
             <div sx={titleStyles}>
@@ -80,7 +106,7 @@ const Search: React.FunctionComponent<SearchProps> = ({
                     />
                 )}
             </div>
-            <div sx={searchBoxStyles}>
+            <div sx={{ ...searchBoxStyles, ...extraSearchBoxStyles }}>
                 <TextInput
                     name="search-text-input"
                     label="Search Content"
@@ -89,6 +115,32 @@ const Search: React.FunctionComponent<SearchProps> = ({
                     onChange={onSearch}
                 />
             </div>
+            {contentType === 'Code Example' && (
+                <div
+                    sx={{
+                        display: 'flex',
+                        gap: 'inc40',
+                        marginBottom: ['inc30', null, 'inc70'],
+                        marginTop: ['inc30', null, 'inc40'],
+                    }}
+                >
+                    <Checkbox
+                        name="Snippet"
+                        label="Code Snippets"
+                        onToggle={checked => onCheckToggle(checked, 'Snippet')}
+                        checked={codeLevelFilters.includes('Snippet')}
+                    />
+                    <Checkbox
+                        name="Full Application"
+                        label="Full Applications"
+                        onToggle={checked =>
+                            onCheckToggle(checked, 'Full Application')
+                        }
+                        checked={codeLevelFilters.includes('Full Application')}
+                    />
+                </div>
+            )}
+            <div sx={{}}></div>
             {!!numberOfResults || isValidating || error ? (
                 <>
                     <Results

--- a/src/components/tag-section/tag-section.tsx
+++ b/src/components/tag-section/tag-section.tsx
@@ -13,9 +13,16 @@ const TagSection: React.FunctionComponent<TagSectionProps> = ({
         {tags
             .filter(
                 tag =>
-                    !['AuthorType', 'ExpertiseLevel', 'ContentType'].includes(
-                        tag.type
-                    )
+                    tag &&
+                    tag.type &&
+                    tag.name &&
+                    tag.slug &&
+                    [
+                        'L1Product',
+                        'L2Product',
+                        'Technology',
+                        'ProgrammingLanguage',
+                    ].includes(tag.type)
             )
             .map(tag => (
                 <Tag

--- a/src/components/tertiary-nav/styles.ts
+++ b/src/components/tertiary-nav/styles.ts
@@ -49,3 +49,11 @@ export const smallDesktopNavFadeLeftStyles = {
     background:
         'linear-gradient(90deg, #FFFFFF 29.17%, rgba(255, 255, 255, 0) 100% )',
 };
+
+export const sideNavTitleStyles = {
+    borderLeft: 'solid',
+    borderWidth: '2px',
+    borderColor: 'black20',
+    paddingBottom: 'inc30',
+    px: 'inc60',
+};

--- a/src/page-templates/content-type/content-type.tsx
+++ b/src/page-templates/content-type/content-type.tsx
@@ -44,6 +44,7 @@ import TechnologiesSection from './technologies-section';
 import ProductsSection from './products-section';
 
 const ContentTypePage: NextPage<ContentTypePageProps> = ({
+    description,
     contentType,
     l1Items,
     languageItems,
@@ -63,7 +64,10 @@ const ContentTypePage: NextPage<ContentTypePageProps> = ({
     const [requestContentModalStage, setRequestContentModalStage] =
         useState<requestContentModalStages>('closed');
     const { data, error, isValidating } = useSWR(
-        () => `s=${searchString}&contentType=${contentType}`,
+        () =>
+            `s=${encodeURIComponent(
+                searchString
+            )}&contentType=${encodeURIComponent(contentType)}`,
         fetcher,
         {
             revalidateIfStale: false,
@@ -283,7 +287,7 @@ const ContentTypePage: NextPage<ContentTypePageProps> = ({
             <Hero
                 crumbs={[]}
                 name={`${contentType}s`}
-                description="Some description"
+                description={description}
                 ctas={CTAElement}
             />
             <div sx={pageWrapper}>

--- a/src/page-templates/content-type/types.ts
+++ b/src/page-templates/content-type/types.ts
@@ -5,6 +5,7 @@ import { ShowcaseCardItem } from '../../components/showcase-card/types';
 import { ITopicCard } from '../../components/topic-card/types';
 
 export interface ContentTypePageProps {
+    description: string;
     contentType: PillCategory;
     l1Items: FilterItem[];
     languageItems: FilterItem[];

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -461,22 +461,22 @@ interface IParams extends ParsedUrlQuery {
     slug: string[];
 } // Need this to avoid TS errors.
 
-const removesErroringArticles = (contents: ContentItem[]) => {
-    const removeItems = [
-        'PyMongoArrow: Bridging the Gap Between MongoDB and Your Data Analysis App',
-        'new-time-series-collections',
-        'mongodb-charts-embedding-sdk-react/',
-        'build-movie-search-application',
-    ];
+// const removesErroringArticles = (contents: ContentItem[]) => {
+//     const removeItems = [
+//         'PyMongoArrow: Bridging the Gap Between MongoDB and Your Data Analysis App',
+//         'new-time-series-collections',
+//         'mongodb-charts-embedding-sdk-react/',
+//         'build-movie-search-application',
+//     ];
 
-    return contents.filter(content => !removeItems.includes(content.title));
-};
+//     return contents.filter(content => !removeItems.includes(content.title));
+// };
 
 export const getStaticPaths = async () => {
     const contents: ContentItem[] = await getAllContentItems();
-    const filteredContents = removesErroringArticles(contents);
+    // const filteredContents = removesErroringArticles(contents);
 
-    const paths = filteredContents.map((content: ContentItem) => ({
+    const paths = contents.map((content: ContentItem) => ({
         params: { slug: content.slug.split('/') },
     }));
     return { paths, fallback: false };

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -12,7 +12,6 @@ import {
     Button,
 } from '@mdb/flora';
 
-import Card, { getCardProps } from '../components/card';
 import TagSection from '../components/tag-section';
 import ContentRating from '../components/content-rating';
 
@@ -45,9 +44,13 @@ import { getPlaceHolderImage } from '../utils/get-place-holder-thumbnail';
 import PodcastPlayer from '../components/podcast-player/podcast-player';
 import { parseAuthorsToAuthorLockup } from '../utils/parse-authors-to-author-lockup';
 import { CollectionType } from '../types/collection-type';
-import { setURLPathForNavItems } from '../utils/format-url-path';
+import { setURLPathForNavItems, getURLPath } from '../utils/format-url-path';
+import { sideNavTitleStyles } from '../components/tertiary-nav/styles';
+import { getMetaInfoForTopic } from '../service/get-meta-info-for-topic';
 
 interface ContentPageProps {
+    topicSlug: string;
+    topicName: string;
     contentItem: ContentItem;
     tertiaryNavItems: TertiaryNavItem[];
 }
@@ -129,6 +132,8 @@ const determineVideoOrPodcast = (
 };
 
 const ContentPage: NextPage<ContentPageProps> = ({
+    topicSlug,
+    topicName,
     contentItem,
     tertiaryNavItems,
 }) => {
@@ -388,6 +393,21 @@ const ContentPage: NextPage<ContentPageProps> = ({
                     }}
                 >
                     <div sx={sideNavStyles}>
+                        <a
+                            href={getURLPath(topicSlug)}
+                            sx={{
+                                '&:hover': {
+                                    textDecoration: 'underline',
+                                },
+                            }}
+                        >
+                            <TypographyScale
+                                variant="heading6"
+                                sx={sideNavTitleStyles}
+                            >
+                                {topicName}
+                            </TypographyScale>
+                        </a>
                         <SideNav currentUrl="#" items={tertiaryNavItems} />
                     </div>
 
@@ -479,9 +499,15 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     let tertiaryNavItems = await getSideNav(sideNavFilterSlug);
     setURLPathForNavItems(tertiaryNavItems);
 
+    const metaInfoForTopic = await getMetaInfoForTopic(sideNavFilterSlug);
+    const topicSlug = sideNavFilterSlug;
+    const topicName = metaInfoForTopic?.tagName ? metaInfoForTopic.tagName : '';
+
     const data = {
         contentItem,
         tertiaryNavItems,
+        topicSlug,
+        topicName,
     };
 
     return { props: data };

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -47,8 +47,12 @@ import { CollectionType } from '../types/collection-type';
 import { setURLPathForNavItems, getURLPath } from '../utils/format-url-path';
 import { sideNavTitleStyles } from '../components/tertiary-nav/styles';
 import { getMetaInfoForTopic } from '../service/get-meta-info-for-topic';
+import { getBreadcrumbsFromSlug } from '../components/breadcrumbs/utils';
+import { Crumb } from '../components/breadcrumbs/types';
+import Breadcrumbs from '../components/breadcrumbs';
 
 interface ContentPageProps {
+    crumbs: Crumb[];
     topicSlug: string;
     topicName: string;
     contentItem: ContentItem;
@@ -132,6 +136,7 @@ const determineVideoOrPodcast = (
 };
 
 const ContentPage: NextPage<ContentPageProps> = ({
+    crumbs,
     topicSlug,
     topicName,
     contentItem,
@@ -205,9 +210,10 @@ const ContentPage: NextPage<ContentPageProps> = ({
     const contentHeader = (
         <>
             <div sx={middleSectionStyles}>
-                <Eyebrow sx={{ marginBottom: ['inc20', null, null, 'inc30'] }}>
-                    {category}
-                </Eyebrow>
+                <Breadcrumbs
+                    crumbs={crumbs}
+                    sx={{ marginBottom: ['inc20', null, null, 'inc30'] }}
+                />
                 <TypographyScale
                     variant="heading2"
                     sx={{
@@ -486,6 +492,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     const vidOrPod = determineVideoOrPodcast(contentItem.collectionType);
     let sideNavFilterSlug = '/' + slug.slice(0, slug.length - 1).join('/');
+    let slugString = slug.join('/');
 
     if (vidOrPod) {
         if (contentItem.primaryTag?.programmingLanguage) {
@@ -495,7 +502,9 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         if (contentItem.primaryTag?.l1Product) {
             sideNavFilterSlug = contentItem.primaryTag.l1Product.calculatedSlug;
         }
+        slugString = sideNavFilterSlug + '/slug'; // Do this so we get all crumbs up until this throwaway one.
     }
+    const crumbs = await getBreadcrumbsFromSlug(slugString);
     let tertiaryNavItems = await getSideNav(sideNavFilterSlug);
     setURLPathForNavItems(tertiaryNavItems);
 
@@ -504,6 +513,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     const topicName = metaInfoForTopic?.tagName ? metaInfoForTopic.tagName : '';
 
     const data = {
+        crumbs,
         contentItem,
         tertiaryNavItems,
         topicSlug,

--- a/src/pages/[l1_l2]/[...slug].tsx
+++ b/src/pages/[l1_l2]/[...slug].tsx
@@ -225,17 +225,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     const slugString = '/' + l1_l2 + '/' + slug.join('/');
 
-    const categoryTag = (await getDistinctTags()).find(
-        tag => tag.slug === slugString
-    );
-
-    if (!categoryTag) {
-        throw Error('Could not find corresponding tag for ' + slugString);
-    }
-
-    const { name } = categoryTag; // Will destruct ctas from this as well when available.
-
-    const metaInfoForTopic = await getMetaInfoForTopic(name);
+    const metaInfoForTopic = await getMetaInfoForTopic(slugString);
 
     const tertiaryNavItems = await getSideNav(slugString);
 
@@ -247,7 +237,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     const featured = parseContentToGetFeatured(content);
 
     const data = {
-        name,
+        name: metaInfoForTopic?.tagName ? metaInfoForTopic.tagName : '',
         slug: slugString,
         content,
         variant,

--- a/src/pages/[l1_l2]/[...slug].tsx
+++ b/src/pages/[l1_l2]/[...slug].tsx
@@ -25,8 +25,11 @@ import { setURLPathForNavItems } from '../../utils/format-url-path';
 import { L1L2_TOPIC_PAGE_TYPES } from '../../data/constants';
 import { parseContentToGetFeatured } from '../../utils/parse-content-to-get-featured';
 import { getMetaInfoForTopic } from '../../service/get-meta-info-for-topic';
+import { Crumb } from '../../components/breadcrumbs/types';
+import { getBreadcrumbsFromSlug } from '../../components/breadcrumbs/utils';
 
 interface TopicProps {
+    crumbs: Crumb[];
     name: string;
     slug: string;
     description: string;
@@ -51,6 +54,7 @@ const sideNavStyles = (rowCount: number) => ({
 });
 
 const Topic: NextPage<TopicProps> = ({
+    crumbs,
     name,
     slug,
     description,
@@ -62,12 +66,6 @@ const Topic: NextPage<TopicProps> = ({
     variant,
     tertiaryNavItems,
 }) => {
-    const crumbs = [
-        { text: 'MongoDB Developer Center', url: '/' },
-        { text: 'Developer Topics', url: '/topics' },
-        { text: 'Products', url: '/' },
-    ];
-
     const contentRows =
         variant === 'heavy'
             ? PillCategoryValues.map(contentType =>
@@ -236,7 +234,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     const featured = parseContentToGetFeatured(content);
 
+    const crumbs = await getBreadcrumbsFromSlug(slugString);
+
     const data = {
+        crumbs,
         name: metaInfoForTopic?.tagName ? metaInfoForTopic.tagName : '',
         slug: slugString,
         content,

--- a/src/pages/[l1_l2]/[topic]/[...slug].tsx
+++ b/src/pages/[l1_l2]/[topic]/[...slug].tsx
@@ -33,6 +33,8 @@ import {
     setURLPathForNavItems,
 } from '../../../utils/format-url-path';
 import { getMetaInfoForTopic } from '../../../service/get-meta-info-for-topic';
+import { getBreadcrumbsFromSlug } from '../../../components/breadcrumbs/utils';
+import { Crumb } from '../../../components/breadcrumbs/types';
 
 const spanAllColumns = {
     width: '100%',
@@ -51,6 +53,7 @@ const sideNavStyles = (rowCount: number) => ({
 });
 
 export interface TopicContentTypePageProps {
+    // crumbs: Crumb[]
     contentType: PillCategory;
     tertiaryNavItems: TertiaryNavItem[];
     topicName: string;
@@ -62,6 +65,7 @@ export interface TopicContentTypePageProps {
 }
 
 const TopicContentTypePage: NextPage<TopicContentTypePageProps> = ({
+    // crumbs,
     contentType,
     tertiaryNavItems,
     topicName,
@@ -242,6 +246,8 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     */
 
     const pathComponents = [l1_l2, topic].concat(slug);
+
+    // const crumbs = await getBreadcrumbsFromSlug(pathComponents.join('/'));
     const contentTypeSlug = '/' + pathComponents[pathComponents.length - 1];
     const topicSlug =
         '/' + pathComponents.slice(0, pathComponents.length - 1).join('/');
@@ -264,6 +270,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     const contentTypeAggregateSlug = pillCategoryToSlug.get(contentType);
 
     const data = {
+        // crumbs,
         contentType: contentType,
         tertiaryNavItems: tertiaryNavItems,
         topicName: metaInfoForTopic?.tagName ? metaInfoForTopic.tagName : '',

--- a/src/pages/[l1_l2]/[topic]/[...slug].tsx
+++ b/src/pages/[l1_l2]/[topic]/[...slug].tsx
@@ -36,7 +36,6 @@ import { getMetaInfoForTopic } from '../../../service/get-meta-info-for-topic';
 import { getAllContentItems } from '../../../service/get-all-content';
 
 const spanAllColumns = {
-    width: '100%',
     gridColumn: ['span 6', null, 'span 8', 'span 12', 'span 9'],
 };
 

--- a/src/pages/[l1_l2]/[topic]/[...slug].tsx
+++ b/src/pages/[l1_l2]/[topic]/[...slug].tsx
@@ -24,7 +24,6 @@ import { ITopicCard } from '../../../components/topic-card/types';
 import { PillCategory, pillCategoryToSlug } from '../../../types/pill-category';
 import { getAllContentTypes } from '../../../service/get-all-content-types';
 import { ContentTypeTag } from '../../../interfaces/tag-type-response';
-import { capitalizeFirstLetter } from '../../../utils/format-string';
 import { L1L2_TOPIC_PAGE_TYPES } from '../../../data/constants';
 
 import { iconStyles } from '../../../components/topic-card/styles';
@@ -32,6 +31,7 @@ import { setURLPathForNavItems } from '../../../utils/format-url-path';
 import { getMetaInfoForTopic } from '../../../service/get-meta-info-for-topic';
 
 const spanAllColumns = {
+    width: '100%',
     gridColumn: ['span 6', null, 'span 8', 'span 12', 'span 9'],
 };
 
@@ -108,10 +108,7 @@ const TopicContentTypePage: NextPage<TopicContentTypePageProps> = ({
                 >
                     {contentType}s
                 </TypographyScale>
-                <TypographyScale variant="body2">
-                    Blurb consisting of a description of the title or tag for
-                    the page. No more than 2 - 3 lines, and 4 column max
-                </TypographyScale>
+                <TypographyScale variant="body2">{description}</TypographyScale>
             </div>
             <div sx={CTAContainerStyles}>
                 <Button
@@ -257,16 +254,14 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     const tertiaryNavItems = await getSideNav(topicSlug);
 
-    const topicName = pathComponents[pathComponents.length - 2];
-
-    const metaInfoForTopic = await getMetaInfoForTopic(topicName);
+    const metaInfoForTopic = await getMetaInfoForTopic(topicSlug);
 
     const contentTypeAggregateSlug = pillCategoryToSlug.get(contentType);
 
     const data = {
         contentType: contentType,
         tertiaryNavItems: tertiaryNavItems,
-        topicName: capitalizeFirstLetter(topicName),
+        topicName: metaInfoForTopic?.tagName ? metaInfoForTopic.tagName : '',
         topicSlug: topicSlug,
         contentTypeSlug: contentTypeSlug,
         contentTypeAggregateSlug: contentTypeAggregateSlug,

--- a/src/pages/[l1_l2]/[topic]/[...slug].tsx
+++ b/src/pages/[l1_l2]/[topic]/[...slug].tsx
@@ -247,11 +247,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     const pathComponents = [l1_l2, topic].concat(slug);
 
-    // const crumbs = await getBreadcrumbsFromSlug(pathComponents.join('/'));
     const contentTypeSlug = '/' + pathComponents[pathComponents.length - 1];
     const topicSlug =
         '/' + pathComponents.slice(0, pathComponents.length - 1).join('/');
-    //
+
     const allContentTypesInStrapi = await getAllContentTypes();
 
     const contentType: PillCategory = allContentTypesInStrapi

--- a/src/pages/[l1_l2]/[topic]/[...slug].tsx
+++ b/src/pages/[l1_l2]/[topic]/[...slug].tsx
@@ -25,9 +25,13 @@ import { PillCategory, pillCategoryToSlug } from '../../../types/pill-category';
 import { getAllContentTypes } from '../../../service/get-all-content-types';
 import { ContentTypeTag } from '../../../interfaces/tag-type-response';
 import { L1L2_TOPIC_PAGE_TYPES } from '../../../data/constants';
+import { sideNavTitleStyles } from '../../../components/tertiary-nav/styles';
 
 import { iconStyles } from '../../../components/topic-card/styles';
-import { setURLPathForNavItems } from '../../../utils/format-url-path';
+import {
+    getURLPath,
+    setURLPathForNavItems,
+} from '../../../utils/format-url-path';
 import { getMetaInfoForTopic } from '../../../service/get-meta-info-for-topic';
 
 const spanAllColumns = {
@@ -45,14 +49,6 @@ const sideNavStyles = (rowCount: number) => ({
     // before render and update this accordingly.
     gridRow: [null, null, null, null, `span ${rowCount}`],
 });
-
-const sideNavTitleStyles = {
-    borderLeft: 'solid',
-    borderWidth: '2px',
-    borderColor: 'black20',
-    paddingBottom: 'inc30',
-    px: 'inc60',
-};
 
 export interface TopicContentTypePageProps {
     contentType: PillCategory;
@@ -137,12 +133,21 @@ const TopicContentTypePage: NextPage<TopicContentTypePageProps> = ({
                     }}
                 >
                     <div sx={sideNavStyles(mainGridDesktopRowsCount)}>
-                        <TypographyScale
-                            variant="heading6"
-                            sx={sideNavTitleStyles}
+                        <a
+                            href={getURLPath(topicSlug)}
+                            sx={{
+                                '&:hover': {
+                                    textDecoration: 'underline',
+                                },
+                            }}
                         >
-                            {topicName}
-                        </TypographyScale>
+                            <TypographyScale
+                                variant="heading6"
+                                sx={sideNavTitleStyles}
+                            >
+                                {topicName}
+                            </TypographyScale>
+                        </a>
 
                         <SideNav currentUrl="#" items={tertiaryNavItems} />
                     </div>

--- a/src/pages/articles.tsx
+++ b/src/pages/articles.tsx
@@ -5,6 +5,7 @@ import { PillCategory } from '../types/pill-category';
 import { ContentTypePageProps } from '../page-templates/content-type/types';
 import { getFilters } from '../page-templates/content-type/utils';
 import { getAllContentItems } from '../service/get-all-content';
+import { getMetaInfoForTopic } from '../service/get-meta-info-for-topic';
 
 const ArticlesPage: NextPage<ContentTypePageProps> = props => {
     return <ContentTypePage {...props} />;
@@ -14,6 +15,10 @@ export const getStaticProps: GetStaticProps = async () => {
     const contentType: PillCategory = 'Article';
     // Pop contentTypeItems out of here becasue we don't filter by it for these pages.
     const { contentTypeItems, ...filters } = await getFilters(contentType);
+    const metaInfoForTopic = await getMetaInfoForTopic('/articles');
+    const description = metaInfoForTopic?.description
+        ? metaInfoForTopic.description
+        : '';
 
     // TODO: When the featured collection is populated, we will hit that and filter by content type.
     const content = await getAllContentItems();
@@ -21,9 +26,8 @@ export const getStaticProps: GetStaticProps = async () => {
         .filter(item => item.category === contentType)
         .sort((a, b) => b.contentDate.localeCompare(a.contentDate))
         .slice(0, 3);
-
     return {
-        props: { contentType, ...filters, featured },
+        props: { contentType, ...filters, featured, description },
     };
 };
 

--- a/src/service/get-meta-info-for-topic.ts
+++ b/src/service/get-meta-info-for-topic.ts
@@ -1,9 +1,7 @@
 import { getAllMetaInfo } from './get-all-meta-info';
 
-export const getMetaInfoForTopic = async (topic: string) => {
+export const getMetaInfoForTopic = async (topicSlug: string) => {
     const metaInfo = await getAllMetaInfo();
-    const metaInfoForTopicName = metaInfo.filter(
-        m => m.tagName.toLowerCase() === topic.toLowerCase()
-    );
+    const metaInfoForTopicName = metaInfo.filter(m => m.slug == topicSlug);
     return metaInfoForTopicName.length > 0 ? metaInfoForTopicName[0] : null;
 };

--- a/src/types/tag-type.ts
+++ b/src/types/tag-type.ts
@@ -6,4 +6,7 @@ export type TagType =
     | 'ExpertiseLevel'
     | 'AuthorType'
     | 'SpokenLanguage'
-    | 'ContentType';
+    | 'ContentType'
+    | 'CodeLevel';
+
+export type CodeLevel = 'Full Application' | 'Snippet';


### PR DESCRIPTION
This covers various bug fixes and missing pieces:

- Added the Code Level (Full Application/Snippet) to cards and as a filter on Topic->Code Examples page.
- Fix bug where a blank tag would show, and be explicit about what tags we want to show in the tag section component.
- Encoded the query params when hitting our realm function.
- On Topic Content Type and Content pages, there is supposed to be a top item on the side nav representing the primary tag, and that's supposed to be a clickable link. That has now been implemented.
- Implemented breadcrumbs in every place they show up in the designs.
- On the Topic Content Page for L1s (e.g. `/products/atlas/articles`), the subitems were not being filtered by which ones have the correct content type. For example, we don't want to sho Full Text Search on that page if there are no articles about Full Text Search (clicking on that link would result in a 404 since no page is built for a topic without content). I filtered these and added the correct links to the subitems.