### PR TITLE
Fix regexes for old devhub js/img/json file rewrites

### DIFF
--- a/config/rewrites.js
+++ b/config/rewrites.js
@@ -113,27 +113,27 @@ const rewrites = [
     {
         source: '/:file.js',
         destination: `${process.env.DEVHUB_URL}/:file.js`,
-        regex: '^/(.+).js$',
+        regex: '^/(.+)\\.js$',
     },
     {
         source: '/page-data/:data*.json',
         destination: `${process.env.DEVHUB_URL}/page-data/:data*.json`,
-        regex: '^/page-data/(.+).json$',
+        regex: '^/page-data/(.+)\\.json$',
     },
     {
         source: '/static/:file.(png|svg|woff|woff2)',
         destination: `${process.env.DEVHUB_URL}/static/:file.png`,
-        regex: '^/static/(.+).(png|svg|woff|woff2)$',
+        regex: '^/static/(.+)\\.(png|svg|woff|woff2)$',
     },
     {
         source: '/images/bios/:image.jpg',
         destination: `${process.env.DEVHUB_URL}/images/bios/:image.jpg`,
-        regex: '^/images/bios/(.+).jpg$',
+        regex: '^/images/bios/(.+)\\.jpg$',
     },
     {
         source: '/images/atf-images/:image*.png',
         destination: `${process.env.DEVHUB_URL}/images/atf-images/:image*.png`,
-        regex: '^/images/atf-images/(.+).png$',
+        regex: '^/images/atf-images/(.+)\\.png$',
     },
 ];
 


### PR DESCRIPTION
Noticed an issue with the regexes used to pull the js/img/json files from the old site and it is causing 404s on pages for nextjs, or anything ending in js. 

Once the production bucket is refreshed with the latest files, I'll make these more specific (e.g. per actual file).