### PR TITLE
[DEVHUB-1216] Add redirect for search page from consistent nav

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -1345,11 +1345,6 @@
         "permanent": true
     },
     {
-        "source": "/learn",
-        "destination": "/",
-        "permanent": true
-    },
-    {
         "source": "/product/atlas",
         "destination": "/products/atlas/",
         "permanent": true

--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -2,16 +2,24 @@ import { NextRequest, NextResponse } from 'next/server';
 import { rewrites } from '../../config/rewrites';
 
 export async function middleware(req: NextRequest) {
-    const { origin, pathname } = req.nextUrl;
+    const { pathname } = req.nextUrl;
 
     // Handles consistent navigation search as well as
     // redirect for /learn page.
     if (pathname == '/learn') {
         const s = req.nextUrl.searchParams.get('text');
         if (s && s.length > 0) {
-            return NextResponse.redirect(`${origin}/developer/search?s=${s}`);
+            const { href, search } = req.nextUrl;
+            req.nextUrl.href = href.replace(search, '');
+            req.nextUrl.pathname = '/search';
+            req.nextUrl.search = `?s=${s}`;
+            req.nextUrl.searchParams.delete('content');
+            req.nextUrl.searchParams.delete('text');
+
+            return NextResponse.redirect(req.nextUrl);
         } else {
-            return NextResponse.redirect(`${origin}/developer`);
+            req.nextUrl.pathname = '/';
+            return NextResponse.redirect(req.nextUrl);
         }
     }
 

--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -2,7 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import { rewrites } from '../../config/rewrites';
 
 export async function middleware(req: NextRequest) {
-    const { pathname } = req.nextUrl;
+    const { origin, pathname } = req.nextUrl;
+
+    // Handles consistent navigation search as well as
+    // redirect for /learn page.
+    if (pathname == '/learn') {
+        const s = req.nextUrl.searchParams.get('text');
+        if (s && s.length > 0) {
+            return NextResponse.redirect(`${origin}/developer/search?s=${s}`);
+        } else {
+            return NextResponse.redirect(`${origin}/developer`);
+        }
+    }
 
     // Rewrites are done in this middleware due to
     // existing issue with SSG and dynamic routing

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "allowJs": true,
         "skipLibCheck": true,
         "strict": true,
+        "downlevelIteration": true,
         "forceConsistentCasingInFileNames": true,
         "noEmit": true,
         "esModuleInterop": true,


### PR DESCRIPTION
Redirect to search page when a search is made from the consistent navigation.

Example: /learn/?content=Articles&text=test
will redirect to:
/search/?s=test

https://devcenter-e4ejjalz2-harikakotipalli.vercel.app/developer/learn/?content=Articles&text=test
