### PR TITLE
SEO Fixes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,7 @@ const configVals = {
     publicRuntimeConfig: {
         absoluteBasePath: `${httpProtocol}://${hostUrl}${basePath}`,
     },
+    trailingSlash: true,
 };
 if (process.env.ANALYZE === 'true') {
     const withBundleAnalyzer = require('@next/bundle-analyzer')({

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -1,5 +1,7 @@
 import type { GetStaticProps, NextPage } from 'next';
 import { NextSeo } from 'next-seo';
+import { useRouter } from 'next/router';
+import getConfig from 'next/config';
 import { ParsedUrlQuery } from 'querystring';
 import Image from 'next/image';
 import React, { useState } from 'react';
@@ -153,6 +155,8 @@ const ContentPage: NextPage<ContentPageProps> = ({
     tertiaryNavItems,
     relatedContent,
 }) => {
+    const router = useRouter();
+    const { publicRuntimeConfig } = getConfig();
     const {
         collectionType,
         authors,
@@ -433,6 +437,9 @@ const ContentPage: NextPage<ContentPageProps> = ({
         handle: seo?.twitter_creator,
         site: seo?.twitter_site,
     };
+    let canonicalUrl = seo?.canonical_url
+        ? seo?.canonical_url
+        : publicRuntimeConfig.absoluteBasePath + router.asPath;
 
     return (
         <>
@@ -441,9 +448,7 @@ const ContentPage: NextPage<ContentPageProps> = ({
                 {...(seo?.meta_description && {
                     description: seo.meta_description,
                 })}
-                {...(seo?.canonical_url && {
-                    canonical: seo.canonical_url,
-                })}
+                canonical={canonicalUrl}
                 openGraph={og}
                 twitter={twitter}
             />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,7 +14,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     const { publicRuntimeConfig } = getConfig();
 
     let canonicalUrl = null;
-    if (router.route !== '/_error') {
+    if (router.route !== '/_error' && router.route !== '/[...slug]') {
         canonicalUrl = publicRuntimeConfig.absoluteBasePath + router.asPath;
     }
 

--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -6,7 +6,7 @@ export async function middleware(req: NextRequest) {
 
     // Handles consistent navigation search as well as
     // redirect for /learn page.
-    if (pathname == '/learn') {
+    if (pathname == '/learn/') {
         const s = req.nextUrl.searchParams.get('text');
         if (s && s.length > 0) {
             const { href, search } = req.nextUrl;
@@ -36,7 +36,7 @@ export async function middleware(req: NextRequest) {
             }
         }
 
-        if (pathname == rewrite.source) {
+        if (pathname == rewrite.source || pathname == `${rewrite.source}/`) {
             destination = rewrite.destination;
         }
 


### PR DESCRIPTION
- Fix issue with canonical on [...slug] route.
- Use trailing slashes, similar to former Developer Hub. This should not affect anything, as this behavior was previously by default redirecting trailing slash paths to be without the trailing slash. Now the behavior will be the opposite.

Example (External Canonical)
https://devcenter-4szrhlbpi-harikakotipalli.vercel.app/developer/products/realm/realm-kotlin-0-6-0/