### PR TITLE
Increase CPU and memory limit for prod resources

### DIFF
--- a/environments/prod.yaml
+++ b/environments/prod.yaml
@@ -34,8 +34,8 @@ probes:
 
 resources:
   limits:
-    cpu: 1
-    memory: 2Gi
+    cpu: 2
+    memory: 6Gi
   requests:
-    cpu: 1
-    memory: 2Gi
+    cpu: 2
+    memory: 6Gi


### PR DESCRIPTION
Noticed that memory usage spiked to ~%50 based on the graph in https://grafana.corp.mongodb.com/d/a164a7f0339f99e89cea5cb47e9be617/kubernetes-compute-resources-workload?orgId=1&refresh=10s&var-datasource=default&var-cluster=&var-namespace=devrel&var-workload=devcenter-frontend-web-app&var-type=Deployment. This should bring any potential spike to < 20%.

CPU usage was low and normal, but a bit high for the workload considering that we are only testing. I will be increasing this to 2 as a precaution. We can reevaluate the usage post-launch, when we have real traffic.

![Screen Shot 2022-05-24 at 10 50 10 AM](https://user-images.githubusercontent.com/7053830/170065351-5d505ef0-2ea4-42fe-aece-ddb8b8a17732.png)
