### PR TITLE
Remove trigger interfering with cron in Drone pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -400,8 +400,6 @@ steps:
         from_secret: drone_token
 
 trigger:
-  branch:
-    - production
   event:
     - cron
   cron:


### PR DESCRIPTION
The branch declaration isn't necessary for the pipeline itself, but configured at the cron level.

Branch can declared in the cron definition on the drone cli:
`drone cron add "mongodb/devcenter" "rebuild-devcenter-prod-cron" @hourly --branch "production"`