### PR TITLE
RSS Feed, author lockup image and card background.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ yarn-error.log*
 
 # editors
 .vscode
+
+# RSS feed generated at build time.
+rss.xml

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 const { redirects } = require('./config/redirects');
 const pageDescriptions = require('./config/seo/descriptions.json');
+const { buildRssFeed } = require('./src/scripts/build-rss-feed.js');
 
 const hostUrl = process.env.VERCEL_URL
     ? process.env.VERCEL_URL
@@ -40,6 +41,14 @@ const configVals = {
         pageDescriptions: pageDescriptions, //TODO: Move to CMS
     },
     trailingSlash: true,
+    webpack: (config, { isServer, dev }) => {
+        if (isServer && !dev) {
+            buildRssFeed(`${httpProtocol}://${hostUrl}${basePath}`).then(() =>
+                console.log('Built RSS feed.')
+            );
+        }
+        return config;
+    },
 };
 if (process.env.ANALYZE === 'true') {
     const withBundleAnalyzer = require('@next/bundle-analyzer')({

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@types/react-truncate": "2.3.4",
         "apollo-link-rest": "0.9.0-rc.1",
         "axios": "^0.27.2",
+        "feed": "4.2.2",
         "graphql": "16.2.0",
         "graphql-anywhere": "4.2.7",
         "hex-rgb": "4.3.0",

--- a/src/components/author-lockup/author-image.tsx
+++ b/src/components/author-lockup/author-image.tsx
@@ -4,6 +4,7 @@ import { TypographyScale } from '@mdb/flora';
 import { avatarPlaceholder, profileImage } from './styles';
 import { getInitials } from './utils';
 import { AuthorImageProps } from './types';
+import { getURLPath } from '../../utils/format-url-path';
 
 const AuthorImage: React.FunctionComponent<AuthorImageProps> = ({
     author,
@@ -36,7 +37,7 @@ const AuthorImage: React.FunctionComponent<AuthorImageProps> = ({
             <Image
                 sx={profileImage(size)}
                 layout="fill"
-                src={src}
+                src={getURLPath(src) as string}
                 alt={alt || ''}
             />
         </div>

--- a/src/components/card/styles.ts
+++ b/src/components/card/styles.ts
@@ -168,6 +168,7 @@ export const cardWrapperStyles = {
         cursor: 'pointer',
     },
     gap: ['inc40', null, null, 'inc50'],
+    bg: theme.colors.panels.card.bg,
 };
 
 export const descriptionStyles = (

--- a/src/scripts/build-rss-feed.js
+++ b/src/scripts/build-rss-feed.js
@@ -1,0 +1,41 @@
+const Feed = require('feed').Feed;
+const fs = require('fs');
+const axios = require('axios').default;
+
+async function buildRssFeed(baseUrl) {
+    const date = new Date();
+
+    const feed = new Feed({
+        title: 'MongoDB Developer Center',
+        description: 'MongoDB Developer Center RSS Feed',
+        id: baseUrl,
+        link: baseUrl,
+        language: 'en',
+        updated: date,
+        generator: 'Next.js using Feed for Node.js',
+        feedLinks: {
+            rss2: `${baseUrl}/rss.xml`,
+        },
+    });
+
+    const searchEndpoint =
+        'https://data.mongodb-api.com/app/devhub-search-service-fldiy/endpoint/search_devcenter?s=';
+    const posts = await axios.get(searchEndpoint);
+
+    posts.data.forEach(post => {
+        const url = `${baseUrl}${post.slug}`;
+        feed.addItem({
+            title: post.name,
+            id: url,
+            link: url,
+            description: post.description,
+            date: new Date(post.date),
+        });
+    });
+
+    fs.writeFileSync('public/rss.xml', feed.rss2());
+}
+
+module.exports = {
+    buildRssFeed,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,6 +2907,13 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+feed@4.2.2:
+  version "4.2.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/feed/-/feed-4.2.2.tgz#865783ef6ed12579e2c44bbef3c9113bc4956a7e"
+  integrity sha1-hleD727RJXnixEu+88kRO8SVan4=
+  dependencies:
+    xml-js "^1.6.11"
+
 figures@^3.2.0:
   version "3.2.0"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -5409,6 +5416,11 @@ sanitize-html@2.7.0:
     parse-srcset "^1.0.2"
     postcss "^8.3.11"
 
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha1-KBYjTiN4vdxOU1T6tcqold9xANk=
+
 saxes@^5.0.1:
   version "5.0.1"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
@@ -6268,6 +6280,13 @@ ws@^7.3.1, ws@^7.4.6:
   version "7.5.7"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
   integrity sha1-ngrHfuUK9w1YMm7P9+hes/o3Xmc=
+
+xml-js@^1.6.11:
+  version "1.6.11"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
+  integrity sha1-kn0vaUf38cGaMW3Y7qNhTosY+Ok=
+  dependencies:
+    sax "^1.2.4"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Jira Ticket:

[DEVHUB-1250](https://jira.mongodb.org/browse/DEVHUB-1250)

Main thing is the RSS Feed. I originally had it running on `getStaticProps` of the homepage, but according to Next: 

> Only assets that are in the public directory at [build time](https://nextjs.org/docs/api-reference/cli#build) will be served by Next.js. Files added at runtime won't be available. We recommend using a third party service like [AWS S3](https://aws.amazon.com/s3/) for persistent file storage.

The issue with doing it outside of the context of the app is that I couldn't it to play well with using modules in the app (like `getAllContentItems`). So I decided to just pull from the search Realm function since it should be the same and only requires a single API request. I put it in the webpack config of the Next config so that it runs before build and can add `rss.xml` to the `public` directory and have that be present when the app is built. (see https://github.com/vercel/next.js/discussions/17479#discussioncomment-434551).

The feed will be available at the same url as the existing DevHub (`/developer/rss.xml`).


Also made some minor design fixes that I noticed.