### PR TITLE
Use textAlign to align text

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -51,7 +51,7 @@ const HomepageSearch: React.FunctionComponent = () => {
                 button: {
                     display: ['none', 'none', 'none', 'block'],
                 },
-                '& label': { width: 'min-content' },
+                '& label': { textAlign: 'left' },
             }}
             onKeyPress={e => {
                 if (e.key === 'Enter') {


### PR DESCRIPTION
Prevents the search bar label from overflowing on mobile