### PR TITLE
[DEVHUB-1293] Consistent Nav for  MongoDB World

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@emotion/css": "11.9.0",
         "@emotion/react": "11.9.0",
         "@emotion/styled": "11.8.1",
-        "@mdb/consistent-nav": "1.2.7",
+        "@mdb/consistent-nav": "1.2.15",
         "@mdb/flora": "0.21.0",
         "@types/react-truncate": "2.3.4",
         "apollo-link-rest": "0.9.0-rc.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,10 +773,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@mdb/consistent-nav@1.2.7":
-  version "1.2.7"
-  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.7.tgz#0ac71beba9b607825982e23c4a000fbdef83abf2"
-  integrity sha1-Cscb66m2B4JZguI8SgAPve+Dq/I=
+"@mdb/consistent-nav@1.2.15":
+  version "1.2.15"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.15.tgz#74defdd055ea5dc0c0fd3e22ba5d7174ed29a956"
+  integrity sha1-dN790FXqXcDA/T4iul1xdO0pqVY=
 
 "@mdb/flora@0.21.0":
   version "0.21.0"


### PR DESCRIPTION
1. The Web Team will begin taking web pages on .com live at 8am EDT on 6/7
2. When the pages that are featured in the latest nav release are live, we will notify everyone in the [#web-navigation](https://mongodb.slack.com/archives/C02BMJU3K36), giving the green light to launch the Consistent Nav across all websites