### PR TITLE
Add same product to logo as Realm

### DIFF
--- a/src/utils/product-to-logo.ts
+++ b/src/utils/product-to-logo.ts
@@ -2,6 +2,7 @@ export const productToLogo: { [key: string]: string } = {
     Atlas: 'atlas_product_family',
     MongoDB: 'mdb_database',
     Realm: 'realm_product_family',
+    'Realm (Mobile)': 'realm_product_family',
     Compass: 'mdb_compass',
     'Cloud Manager': 'atlas_cloud_manager',
     'Ops Manager': 'mdb_ops_manager',


### PR DESCRIPTION
Seems like we need "Realm (Mobile)" for the homepage. I missed this and am creating this PR as a correction.