### PR TITLE
Include origin in put/post headers

### DIFF
--- a/src/components/feedback-modal/feedback-modal.tsx
+++ b/src/components/feedback-modal/feedback-modal.tsx
@@ -8,7 +8,9 @@ import axios from 'axios';
 import { getURLPath } from '../../utils/format-url-path';
 
 const updateFeedback = (body: ITextFeedback | ICheckboxFeedback) =>
-    axios.put(getURLPath('/api/updateFeedback') as string, body);
+    axios.put(getURLPath('/api/updateFeedback') as string, body, {
+        headers: { Origin: origin },
+    });
 
 const FeedbackModal: React.FunctionComponent<FeedbackModalProps> = ({
     setModalStage,

--- a/src/components/request-content-modal/request-content.modal.tsx
+++ b/src/components/request-content-modal/request-content.modal.tsx
@@ -16,7 +16,13 @@ const RequestContentModal: React.FunctionComponent<
             email,
         };
 
-        axios.post(getURLPath('/api/requestContent') as string, contentRequest);
+        axios.post(
+            getURLPath('/api/requestContent') as string,
+            contentRequest,
+            {
+                headers: { Origin: origin },
+            }
+        );
     };
 
     return (

--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -13,7 +13,8 @@ const limiter = rateLimit({
 const MAX_FEEDBACK_PER_PERIOD = 10; // 10 requests per 30 seconds per IP.
 
 export async function middleware(req: NextRequest) {
-    const { pathname, origin } = req.nextUrl;
+    const { pathname } = req.nextUrl;
+    const origin = req.headers.get('Origin') || '';
 
     const host = process.env.VERCEL_URL
         ? process.env.VERCEL_URL


### PR DESCRIPTION
`req.nextUrl.origin` is not actually the request origin apparently, just the origin of the next server ([which is always gonna be `loclhost` I guess?](https://github.com/vercel/next.js/blob/canary/packages/next/server/web/next-url.ts#L258)). Now we grab the origin from the browser and pass it as a header.