### PR TITLE
Take out user agent checks and move rate limiting

### DIFF
--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -1,16 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { rewrites } from '../../config/rewrites';
-import rateLimit from '../utils/rate-limit';
-
-// https://github.com/vercel/next.js/tree/canary/examples/api-routes-rate-limit
-// Modified version of this ^^^
-
-const limiter = rateLimit({
-    max: 600, // cache limit of 600 per 30 second period.
-    ttl: 30 * 1000,
-});
-
-const MAX_FEEDBACK_PER_PERIOD = 10; // 10 requests per 30 seconds per IP.
 
 export async function middleware(req: NextRequest) {
     const { pathname } = req.nextUrl;
@@ -28,24 +17,7 @@ export async function middleware(req: NextRequest) {
             'Content-Type': 'application/json',
         };
 
-        // Rate limit
-        try {
-            await limiter.check(headers, MAX_FEEDBACK_PER_PERIOD, req.ip || '');
-        } catch {
-            return new NextResponse(
-                JSON.stringify({
-                    error: { message: 'Something went wrong' },
-                }),
-                {
-                    status: 500,
-                    headers,
-                }
-            );
-        }
-
-        // Minimal bot detection by checking the user agent for real browser info.
         if (
-            !req.ua?.browser?.name ||
             origin.replace(/^(https?:|)\/\//, '') !== host // Remove the protocol from the URL.
         ) {
             console.log(

--- a/src/pages/api/createFeedback.ts
+++ b/src/pages/api/createFeedback.ts
@@ -1,7 +1,28 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import axios from 'axios';
 
+import rateLimit from '../../utils/rate-limit';
+
+const limiter = rateLimit({
+    max: 600, // cache limit of 600 per 30 second period.
+    ttl: 30 * 1000,
+});
+
+const MAX_FEEDBACK_PER_PERIOD = 10;
+
 export default async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+        await limiter.check(
+            res,
+            MAX_FEEDBACK_PER_PERIOD,
+            req.socket.remoteAddress || ''
+        );
+    } catch {
+        return res.status(500).json({
+            error: { message: 'Something went wrong' },
+        });
+    }
+
     if (req.method !== 'POST') {
         return res
             .status(405)

--- a/src/pages/api/requestContent.ts
+++ b/src/pages/api/requestContent.ts
@@ -1,7 +1,28 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import axios from 'axios';
 
+import rateLimit from '../../utils/rate-limit';
+
+const limiter = rateLimit({
+    max: 600, // cache limit of 600 per 30 second period.
+    ttl: 30 * 1000,
+});
+
+const MAX_CONTENT_REQUEST_PER_PERIOD = 10;
+
 export default async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+        await limiter.check(
+            res,
+            MAX_CONTENT_REQUEST_PER_PERIOD,
+            req.socket.remoteAddress || ''
+        );
+    } catch {
+        return res.status(500).json({
+            error: { message: 'Something went wrong' },
+        });
+    }
+
     if (req.method !== 'POST') {
         return res
             .status(405)

--- a/src/pages/api/updateFeedback.ts
+++ b/src/pages/api/updateFeedback.ts
@@ -1,7 +1,28 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import axios from 'axios';
 
+import rateLimit from '../../utils/rate-limit';
+
+const limiter = rateLimit({
+    max: 600, // cache limit of 600 per 30 second period.
+    ttl: 30 * 1000,
+});
+
+const MAX_FEEDBACK_PER_PERIOD = 10;
+
 export default async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+        await limiter.check(
+            res,
+            MAX_FEEDBACK_PER_PERIOD,
+            req.socket.remoteAddress || ''
+        );
+    } catch {
+        return res.status(500).json({
+            error: { message: 'Something went wrong' },
+        });
+    }
+
     if (req.method !== 'PUT') {
         return res
             .status(405)

--- a/src/utils/rate-limit.ts
+++ b/src/utils/rate-limit.ts
@@ -1,5 +1,7 @@
 // https://github.com/vercel/next.js/blob/canary/examples/api-routes-rate-limit/utils/rate-limit.js
 
+import { NextApiResponse } from 'next';
+
 const LRU = require('lru-cache');
 
 interface RateLimitOptions {
@@ -14,11 +16,7 @@ const rateLimit = (options: RateLimitOptions) => {
     });
 
     return {
-        check: (
-            headers: { [key: string]: string },
-            limit: number,
-            ip: string
-        ) =>
+        check: (res: NextApiResponse, limit: number, ip: string) =>
             new Promise((resolve, reject) => {
                 const ipCount = ipCache.get(ip) || [0];
                 if (ipCount[0] === 0) {
@@ -28,10 +26,11 @@ const rateLimit = (options: RateLimitOptions) => {
 
                 const currentUsage = ipCount[0];
                 const isRateLimited = currentUsage >= limit;
-                headers['X-RateLimit-Limit'] = limit.toString();
-                headers['X-RateLimit-Remaining'] = isRateLimited
-                    ? '0'
-                    : (limit - currentUsage).toString();
+                res.setHeader('X-RateLimit-Limit', limit.toString());
+                res.setHeader(
+                    'X-RateLimit-Remaining',
+                    isRateLimited ? '0' : (limit - currentUsage).toString()
+                );
                 if (isRateLimited) {
                     console.log(`IP (${ip}) blocked for too many requests.`);
                     return reject();


### PR DESCRIPTION
So the user agent checks weren't working, not sure why, but they're [changing around the behavior of that attribute soon anyway](https://github.com/vercel/next.js/pull/37512). The `ip` attribute on the `NextRequest` was also not working, so I put the IP checking and rate limiting in the api routes themselves. This is less Ideal, but it might work.