### PR TITLE
Jw/devhub 1294

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -28,6 +28,16 @@ const logger = pino({
     timestamp: stdTimeFunctions.isoTime, // built-in ISO 8601-formatted time in UTC
 });
 
+const URL_NOT_TO_LOG = new Set<string | undefined>(['/api/health/']);
+
+function should_not_log<T>(data: T, to_exclude: Set<T>): boolean {
+    if (data === undefined) {
+        return true;
+    }
+
+    return to_exclude.has(data);
+}
+
 export function logRequestData(
     url: string | undefined,
     method: string | undefined,
@@ -39,6 +49,10 @@ export function logRequestData(
         method: method,
         statusCode: statusCode,
     };
+
+    if (should_not_log(logData.url, URL_NOT_TO_LOG)) {
+        return;
+    }
 
     if (level === undefined) {
         if (statusCode >= 500 && statusCode <= 599) {


### PR DESCRIPTION
To avoid /api/health/ flooding the logs, logic is added in the logger to skip logging /api/health/.