### PR TITLE
Add headers to request logs

### DIFF
--- a/src/pages/api/createFeedback.ts
+++ b/src/pages/api/createFeedback.ts
@@ -20,13 +20,13 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         );
     } catch {
         res = res.status(500);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
         return res.json({ error: { message: 'Something went wrong' } });
     }
 
     if (req.method !== 'POST') {
         res = res.status(405);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
         return res.json({ message: 'This is a POST-only endpoint.' });
     }
     try {
@@ -41,11 +41,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
             }
         );
         res = res.status(200);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
         return res.status(200).json(response.data);
     } catch (err) {
         res = res.status(500);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
         return res.json({ message: 'Something went wrong' });
     }
 };

--- a/src/pages/api/requestContent.ts
+++ b/src/pages/api/requestContent.ts
@@ -20,7 +20,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         );
     } catch {
         res = res.status(500);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
 
         return res.json({
             error: { message: 'Something went wrong' },
@@ -29,7 +29,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     if (req.method !== 'POST') {
         res = res.status(405);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
 
         return res.json({ message: 'This is a POST-only endpoint.' });
     }
@@ -46,12 +46,12 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         );
 
         res = res.status(200);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
 
         return res.json(response.data);
     } catch (err) {
         res = res.status(500);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
         return res.json({ message: 'Something went wrong' });
     }
 };

--- a/src/pages/api/updateFeedback.ts
+++ b/src/pages/api/updateFeedback.ts
@@ -20,7 +20,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         );
     } catch {
         res = res.status(500);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
 
         return res.json({
             error: { message: 'Something went wrong' },
@@ -29,7 +29,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     if (req.method !== 'PUT') {
         res = res.status(405);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
 
         return res.json({ message: 'This is a PUT-only endpoint.' });
     }
@@ -45,12 +45,12 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
             }
         );
         res = res.status(200);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
 
         return res.json(response.data);
     } catch (err) {
         res = res.status(500);
-        logRequestData(req.url, req.method, res.statusCode);
+        logRequestData(req.url, req.method, res.statusCode, req.headers);
         return res.json({ message: 'Something went wrong' });
     }
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,4 @@
+import { IncomingHttpHeaders } from 'http';
 import pino, { stdTimeFunctions } from 'pino';
 
 /*
@@ -32,12 +33,14 @@ export function logRequestData(
     url: string | undefined,
     method: string | undefined,
     statusCode: number,
+    headers?: IncomingHttpHeaders,
     level?: pino.Level
 ): void {
     const logData = {
-        url: url,
-        method: method,
-        statusCode: statusCode,
+        url,
+        method,
+        statusCode,
+        headers,
     };
 
     if (level === undefined) {


### PR DESCRIPTION
I mainly want to be able to see if Kanopy passes a header with the client IP address. We don't have to log these headers after I find that out, but it might be nice to have that functionality just in case.