### PR TITLE
DEVHUB-1180: Homepage: Desktop - product card description text incorrect size

### DIFF
--- a/src/components/showcase-card/showcase-card.tsx
+++ b/src/components/showcase-card/showcase-card.tsx
@@ -72,7 +72,9 @@ const ShowcaseCard: React.FunctionComponent<ShowcaseCardProps> = ({
                     {titleLink.text}
                 </Link>
             )}
-            {!!description && <TypographyScale>{description}</TypographyScale>}
+            {!!description && (
+                <TypographyScale variant="body3">{description}</TypographyScale>
+            )}
             {!!links && (
                 <div>
                     {links.map(link => (


### PR DESCRIPTION
Adds `variant` to `<TypographyScale />` component for correct font-size.

[DEVHUB-1180](https://jira.mongodb.org/browse/DEVHUB-1180)