### PR TITLE
DEVHUB-1262: Sort Technologies Alphabetically

### DIFF
--- a/src/pages/technologies.tsx
+++ b/src/pages/technologies.tsx
@@ -87,7 +87,11 @@ export const getStaticProps: GetStaticProps<{
     technologies: MetaInfo[];
 }> = async () => {
     const tags = await getAllMetaInfo();
-    const technologies = tags.filter(tag => tag.category === 'Technology');
+    const technologies = tags
+        .filter(tag => tag.category === 'Technology')
+        .sort((prev, next) =>
+            prev.tagName.toLowerCase().localeCompare(next.tagName.toLowerCase())
+        );
 
     return {
         props: { technologies },


### PR DESCRIPTION
[Ticket](https://jira.mongodb.org/browse/DEVHUB-1262)

Sorts list of technologies [here](https://www.mongodb.com/developer/technologies/) in alphabetical order.

**DEV NOTE:** Does not take into account anything pre-pended with special chars (e.g. `.Net`), those will show up first. Will confirm with Rachelle if this is the desired result.