### PR TITLE
DEVHUB-1220: Secondary Nav: Mobile: Gap in nav border

### DIFF
--- a/src/components/seconardynavnew/mobile-styles.ts
+++ b/src/components/seconardynavnew/mobile-styles.ts
@@ -1,5 +1,8 @@
 import { ThemeUIStyleObject } from 'theme-ui';
 
+export const MobileMenuActiveBorder = '#00ED64';
+export const MobileMenuDefaultBorder = '#00684A';
+
 export const secondaryLinkStyles = (isOpen: boolean): ThemeUIStyleObject => ({
     margin: 0,
     display: isOpen ? 'block' : 'none',
@@ -22,7 +25,6 @@ export const secondaryLinkStyles = (isOpen: boolean): ThemeUIStyleObject => ({
     },
 });
 export const MainLinkStyles = {
-    borderBottom: 'solid #00684A 2px',
     fontSize: 'inc30',
     fontWeight: 500,
     paddingLeft: 'inc50',

--- a/src/components/seconardynavnew/mobile-styles.ts
+++ b/src/components/seconardynavnew/mobile-styles.ts
@@ -1,8 +1,5 @@
 import { ThemeUIStyleObject } from 'theme-ui';
 
-export const MobileMenuActiveBorder = '#00ED64';
-export const MobileMenuDefaultBorder = '#00684A';
-
 export const secondaryLinkStyles = (isOpen: boolean): ThemeUIStyleObject => ({
     margin: 0,
     display: isOpen ? 'block' : 'none',

--- a/src/components/seconardynavnew/mobile.tsx
+++ b/src/components/seconardynavnew/mobile.tsx
@@ -16,6 +16,8 @@ import {
     StylesFloraLink,
     StylesFloraLinkChevronRight,
     StylesSubLinks,
+    MobileMenuActiveBorder,
+    MobileMenuDefaultBorder,
 } from './mobile-styles';
 import { DropDownItem, DropDownItem2 } from './dropdown-menu';
 import { getURLPath } from '../../utils/format-url-path';
@@ -315,16 +317,28 @@ const MobileView = () => {
                 zIndex: '10',
             }}
         >
-            <div sx={{ display: 'grid', gridTemplateColumns: '240px 1fr' }}>
-                <FloraLink
-                    sx={{
-                        ...MainLinkStyles,
-                        ...(mobileMenuIsOpen && {
-                            borderBottom: 'solid #00ED64 2px',
-                        }),
-                    }}
-                    onClick={openMobileMenu}
-                >
+            <div
+                sx={{
+                    display: 'grid',
+                    gridTemplateColumns: '240px 1fr',
+                    position: 'relative',
+                    borderBottom: '2px solid',
+                    borderBottomColor: mobileMenuIsOpen
+                        ? MobileMenuActiveBorder
+                        : MobileMenuDefaultBorder,
+                    // [DEVHUB-1220]: using pseudo el to prevent gap in sibling element bottom-borders in mobile browser
+                    '&:after': {
+                        position: 'absolute',
+                        background: MobileMenuDefaultBorder,
+                        height: '2px',
+                        content: '""',
+                        width: '100%',
+                        bottom: '-2px',
+                        left: '240px',
+                    },
+                }}
+            >
+                <FloraLink sx={{ ...MainLinkStyles }} onClick={openMobileMenu}>
                     <TypographyScale variant="body1">
                         MongoDB Developer
                     </TypographyScale>
@@ -334,6 +348,7 @@ const MobileView = () => {
                             className="chevron-icon"
                             name={ESystemIconNames.CHEVRON_DOWN}
                             size="small"
+                            strokeWeight="large"
                         />
                     )}
                     {mobileMenuIsOpen && (
@@ -350,7 +365,6 @@ const MobileView = () => {
                     sx={{
                         height: '68px',
                         width: '100%',
-                        borderBottom: 'solid 2px #00684A',
                     }}
                 ></div>
             </div>

--- a/src/components/seconardynavnew/mobile.tsx
+++ b/src/components/seconardynavnew/mobile.tsx
@@ -16,8 +16,6 @@ import {
     StylesFloraLink,
     StylesFloraLinkChevronRight,
     StylesSubLinks,
-    MobileMenuActiveBorder,
-    MobileMenuDefaultBorder,
 } from './mobile-styles';
 import { DropDownItem, DropDownItem2 } from './dropdown-menu';
 import { getURLPath } from '../../utils/format-url-path';
@@ -321,21 +319,12 @@ const MobileView = () => {
                 sx={{
                     display: 'grid',
                     gridTemplateColumns: '240px 1fr',
-                    position: 'relative',
-                    borderBottom: '2px solid',
-                    borderBottomColor: mobileMenuIsOpen
-                        ? MobileMenuActiveBorder
-                        : MobileMenuDefaultBorder,
-                    // [DEVHUB-1220]: using pseudo el to prevent gap in sibling element bottom-borders in mobile browser
-                    '&:after': {
-                        position: 'absolute',
-                        background: MobileMenuDefaultBorder,
-                        height: '2px',
-                        content: '""',
-                        width: '100%',
-                        bottom: '-2px',
-                        left: '240px',
-                    },
+                    border: 'none',
+                    borderBottom: '2px solid #00684A',
+                    ...(mobileMenuIsOpen && {
+                        borderImage:
+                            'linear-gradient(to right, #00ED64 240px, #00684A 0) 1',
+                    }),
                 }}
             >
                 <FloraLink sx={{ ...MainLinkStyles }} onClick={openMobileMenu}>

--- a/src/components/seconardynavnew/mobile.tsx
+++ b/src/components/seconardynavnew/mobile.tsx
@@ -319,7 +319,6 @@ const MobileView = () => {
                 sx={{
                     display: 'grid',
                     gridTemplateColumns: '240px 1fr',
-                    border: 'none',
                     borderBottom: '2px solid #00684A',
                     ...(mobileMenuIsOpen && {
                         borderImage:


### PR DESCRIPTION
Ticket: https://jira.mongodb.org/browse/DEVHUB-1220

Scope:
- Sibling elements with separate bottom borders was creating a small gap in the border in mobile browsers. I moved the border up to the wrapping parent element and used `border-image` instead to achieve the active color/default border split.
- Added `strokeWeight="large"` to closed chevron in mobile view after Mike pointed it out to match open chevron's `strokeWeight`

Screenshot from current PROD:
![Screen Shot 2022-07-06 at 12 34 11 PM](https://user-images.githubusercontent.com/20843509/177600091-bf9f4e1d-29e2-4c8a-a5c2-7e166def59c0.png)

Screenshot with `border-image` change:
![Screen Shot 2022-07-06 at 12 34 20 PM](https://user-images.githubusercontent.com/20843509/177600168-d5ff52b3-c6dd-4a5c-b076-02b2114b9a5e.png)