### PR TITLE
[DEVHUB-1256] Added Aggregated News & Announcement Page

### DIFF
--- a/playwright-tests/pages/index.spec.ts
+++ b/playwright-tests/pages/index.spec.ts
@@ -1,12 +1,5 @@
 import { test, expect } from '@playwright/test';
-
-const allLinksHaveHref = async (links, href) => {
-    const linksCount = await links.count();
-    for (let i = 0; i < linksCount; i++) {
-        const el = await links.nth(i);
-        expect(await el.getAttribute('href')).toBe(href);
-    }
-};
+import { allLinksHaveHref } from '../utils';
 
 test('Homepage has correct titles', async ({ page }) => {
     await page.goto('/developer');

--- a/playwright-tests/pages/news.spec.ts
+++ b/playwright-tests/pages/news.spec.ts
@@ -7,6 +7,12 @@ test('All News & Announcements Page has correct titles', async ({ page }) => {
 
     const sectionTitles = page.locator('h5');
     const text = await sectionTitles.allTextContents();
-    expect(text[0]).toEqual('Featured News & Announcements');
-    expect(text[1]).toEqual('All News & Announcements');
+
+    const expected = [
+        'Featured News & Announcements',
+        'All News & Announcements',
+    ];
+
+    // https://jestjs.io/docs/expect#expectarraycontainingarray
+    expect(text).toEqual(expect.arrayContaining(expected));
 });

--- a/playwright-tests/pages/news.spec.ts
+++ b/playwright-tests/pages/news.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('All News & Announcements Page has correct titles', async ({ page }) => {
+    await page.goto('/developer/news');
+    const title = page.locator('h1');
+    await expect(title).toHaveText('News & Announcements');
+
+    const sectionTitles = page.locator('h5');
+    const text = await sectionTitles.allTextContents();
+    expect(text[0]).toEqual('Featured News & Announcements');
+    expect(text[1]).toEqual('All News & Announcements');
+});

--- a/playwright-tests/utils.ts
+++ b/playwright-tests/utils.ts
@@ -1,0 +1,9 @@
+import { expect } from '@playwright/test';
+
+export const allLinksHaveHref = async (links, href) => {
+    const linksCount = await links.count();
+    for (let i = 0; i < linksCount; i++) {
+        const el = await links.nth(i);
+        expect(await el.getAttribute('href')).toBe(href);
+    }
+};

--- a/src/components/card-section/card-section.tsx
+++ b/src/components/card-section/card-section.tsx
@@ -56,6 +56,7 @@ const CardSection: React.FunctionComponent<CardSectionProps> = ({
         ),
         [content]
     );
+
     return (
         <div
             data-testid={`${title

--- a/src/page-templates/content-type/content-type.tsx
+++ b/src/page-templates/content-type/content-type.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ContextType, useState } from 'react';
 import type { NextPage } from 'next';
 import NextImage from 'next/image';
 import { NextSeo } from 'next-seo';
@@ -40,6 +40,9 @@ import { getURLPath } from '../../utils/format-url-path';
 import { thumbnailLoader } from '../../components/card/utils';
 import useSearch from '../../hooks/search';
 import FilterTagSection from '../../components/search-filters/filter-tag-section';
+
+import { shouldRenderRequestButton } from './utils';
+
 let pluralize = require('pluralize');
 
 const ContentTypePage: NextPage<ContentTypePageProps> = ({
@@ -162,7 +165,7 @@ const ContentTypePage: NextPage<ContentTypePageProps> = ({
             {(data || isValidating) && (
                 <TypographyScale variant="heading5">
                     {!allFilters.length && !searchString
-                        ? `All ${contentType}s`
+                        ? `All ${pluralize(contentType)}`
                         : isValidating
                         ? ''
                         : numberOfResults === 1
@@ -218,7 +221,9 @@ const ContentTypePage: NextPage<ContentTypePageProps> = ({
                 crumbs={[{ text: 'MongoDB Developer Center', url: '/' }]}
                 name={pluralize(contentType)}
                 description={description}
-                ctas={CTAElement}
+                ctas={
+                    shouldRenderRequestButton(contentType) ? CTAElement : null
+                }
             />
             <div sx={pageWrapper}>
                 <GridLayout
@@ -247,7 +252,7 @@ const ContentTypePage: NextPage<ContentTypePageProps> = ({
                         <div sx={searchBoxStyles}>
                             <TextInput
                                 name="search-text-input"
-                                label={`Search ${contentType}s`}
+                                label={`Search ${pluralize(contentType)}`}
                                 iconName={ESystemIconNames.SEARCH}
                                 value={searchString}
                                 onChange={onSearch}
@@ -264,7 +269,7 @@ const ContentTypePage: NextPage<ContentTypePageProps> = ({
                                             'section50',
                                         ],
                                     }}
-                                    title={`Featured ${contentType}s`}
+                                    title={`Featured ${pluralize(contentType)}`}
                                 />
                                 {hasExtraSections && (
                                     <>

--- a/src/page-templates/content-type/utils.ts
+++ b/src/page-templates/content-type/utils.ts
@@ -5,6 +5,7 @@ import { languageToLogo } from '../../utils/language-to-logo';
 import { technologyToLogo } from '../../utils/technology-to-logo';
 import { productToLogo } from '../../utils/product-to-logo';
 import { ITopicCard } from '../../components/topic-card/types';
+import { PillCategory } from '../../types/pill-category';
 
 // Temporary until we find a logo to include in Flora.
 const serverlessLogo =
@@ -119,3 +120,10 @@ export const getFeaturedLangProdTech = (
     });
     return { featuredLanguages, featuredTechnologies, featuredProducts };
 };
+
+export function shouldRenderRequestButton(contentType: PillCategory): boolean {
+    const shouldNotRenderSet: Set<PillCategory> = new Set([
+        'News & Announcements',
+    ]);
+    return !shouldNotRenderSet.has(contentType);
+}

--- a/src/page-templates/topic-content-type-page/topic-content-type-page-template.tsx
+++ b/src/page-templates/topic-content-type-page/topic-content-type-page-template.tsx
@@ -49,9 +49,6 @@ const getSearchTitleLink = (
     contentType: PillCategory,
     contentTypeAggregateSlug: string
 ) => {
-    if (contentType === 'News & Announcements') {
-        return undefined;
-    }
     if (contentType === 'Podcast') {
         return {
             href: 'https://podcasts.mongodb.com/public/115/The-MongoDB-Podcast-b02cf624',
@@ -144,6 +141,12 @@ export const TopicContentTypePageTemplate: NextPage<
             )}
         </GridLayout>
     );
+
+    console.log('PRINT');
+    console.log(contentType);
+    console.log(contentTypeAggregateSlug);
+    console.log(getSearchTitleLink(contentType, contentTypeAggregateSlug));
+    console.log('PRINT');
 
     return (
         <>

--- a/src/page-templates/topic-content-type-page/topic-content-type-page-template.tsx
+++ b/src/page-templates/topic-content-type-page/topic-content-type-page-template.tsx
@@ -142,12 +142,6 @@ export const TopicContentTypePageTemplate: NextPage<
         </GridLayout>
     );
 
-    console.log('PRINT');
-    console.log(contentType);
-    console.log(contentTypeAggregateSlug);
-    console.log(getSearchTitleLink(contentType, contentTypeAggregateSlug));
-    console.log('PRINT');
-
     return (
         <>
             <NextSeo title={pageTitle} />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -50,7 +50,7 @@ function MyApp({ Component, pageProps }: AppProps) {
                 )}
             </Head>
             {/* Google Tag Manager - Global base code */}
-            <Script
+            {/* <Script
                 id="gtag-base"
                 strategy="afterInteractive"
                 dangerouslySetInnerHTML={{
@@ -62,7 +62,7 @@ function MyApp({ Component, pageProps }: AppProps) {
                 })(window,document,'script','dataLayer', '${GTM_ID}');
                 `,
                 }}
-            />
+            /> */}
             <ThemeProvider theme={theme}>
                 <Layout>
                     <Component {...pageProps} />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -50,7 +50,7 @@ function MyApp({ Component, pageProps }: AppProps) {
                 )}
             </Head>
             {/* Google Tag Manager - Global base code */}
-            {/* <Script
+            <Script
                 id="gtag-base"
                 strategy="afterInteractive"
                 dangerouslySetInnerHTML={{
@@ -62,7 +62,7 @@ function MyApp({ Component, pageProps }: AppProps) {
                 })(window,document,'script','dataLayer', '${GTM_ID}');
                 `,
                 }}
-            /> */}
+            />
             <ThemeProvider theme={theme}>
                 <Layout>
                     <Component {...pageProps} />

--- a/src/pages/news.tsx
+++ b/src/pages/news.tsx
@@ -1,0 +1,18 @@
+import type { NextPage, GetStaticProps } from 'next';
+
+import ContentTypePage from '../page-templates/content-type';
+import { ContentTypePageProps } from '../page-templates/content-type/types';
+import { getContentTypePageData } from '../page-templates/content-type/content-type-data';
+
+const NewsPage: NextPage<ContentTypePageProps> = props => {
+    return <ContentTypePage {...props} />;
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+    const data = await getContentTypePageData('News & Announcements');
+    return {
+        props: data,
+    };
+};
+
+export default NewsPage;


### PR DESCRIPTION
Added an aggregated news & announcement page to `/news` route:
- Hid "Request an X" button for news & announcements
- Pluralized couple content type to fix the extra "s" at the end  
- Added "All News & Announcements" link
- Incorporated a simple PlayWright Test

To access the page, please click All News & Announcements link on News & Announcement of a particular product. For example, land on `/products/atlas/news/` and click All News & Announcement. 