### PR TITLE
[DEVHUB-1239]: MOBILE: Text on feature cards should be consistent

### DIFF
--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -134,19 +134,12 @@ const Card: React.FunctionComponent<CardProps> = ({
                         variant={variant === 'large' ? 'heading5' : 'heading6'}
                         sx={{
                             ...(variant === 'large' && {
-                                fontSize: [
-                                    null,
-                                    'inc30',
-                                    'inc50',
-                                    'inc80',
-                                    null,
-                                ],
+                                fontSize: ['inc30', 'inc30', 'inc50', 'inc80'],
                                 lineHeight: [
-                                    null,
+                                    'inc20',
                                     'inc20',
                                     'inc30',
                                     'inc50',
-                                    null,
                                 ],
                             }),
                         }}


### PR DESCRIPTION
Ticket: https://jira.mongodb.org/browse/DEVHUB-1239

**Scope:**
- Overrides `<TypographyScale />` responsive text sizing because the first "Featured Card" in "Articles" is always passed `variant="large"` and the first card needs to match the other featured card's font sizes when in mobile (row) view.

Note: I am unsure if this will have unintentional side effects on other places where `<Card />` is used.