### PR TITLE
[DEVHUB-1350] Enable rating feature for other content types

### DIFF
--- a/src/page-templates/main-content-page/content-page-template.tsx
+++ b/src/page-templates/main-content-page/content-page-template.tsx
@@ -386,7 +386,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                             authors={authors}
                             tags={tags}
                         />
-                        {!ratingSectionCondition(category) && ratingSection}
+                        {ratingSection}
                     </div>
                 )}
             </div>

--- a/src/page-templates/main-content-page/content-page-template.tsx
+++ b/src/page-templates/main-content-page/content-page-template.tsx
@@ -54,6 +54,8 @@ import Breadcrumbs from '../../components/breadcrumbs';
 import { TableOfContents } from '../../components/article-body/table-of-contents';
 import { IRating } from '../../components/feedback-modal/types';
 
+import { normalizeCategory } from './util';
+
 interface ContentPageProps {
     crumbs: Crumb[];
     topicSlug: string;
@@ -217,7 +219,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                 alignItems: 'center',
             }}
         >
-            <span>Rate this {category.toLowerCase()}</span>
+            <span>Rate this {normalizeCategory(category)}</span>
             <ContentRating stars={ratingStars} onRate={onRate} />
         </div>
     );

--- a/src/page-templates/main-content-page/content-page-template.tsx
+++ b/src/page-templates/main-content-page/content-page-template.tsx
@@ -127,15 +127,6 @@ export const determineVideoOrPodcast = (
     return collectionType === 'Video' || collectionType === 'Podcast';
 };
 
-const ratingSectionCondition = (category: PillCategory) => {
-    return (
-        category === 'Video' ||
-        category === 'Podcast' ||
-        category === 'News & Announcements' ||
-        category === 'Code Example'
-    );
-};
-
 const ContentPageTemplate: NextPage<ContentPageProps> = ({
     crumbs,
     topicSlug,
@@ -320,9 +311,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                         />
                     )}
                 </div>
-                {!previewMode &&
-                    !ratingSectionCondition(category) &&
-                    ratingSection}
+                {!previewMode && ratingSection}
             </div>
         </>
     );

--- a/src/page-templates/main-content-page/util.ts
+++ b/src/page-templates/main-content-page/util.ts
@@ -1,0 +1,9 @@
+import { PillCategory } from '../../types/pill-category';
+
+export function normalizeCategory(category: PillCategory): string {
+    if (category === 'News & Announcements') {
+        return 'announcement';
+    }
+
+    return category.toLowerCase();
+}


### PR DESCRIPTION
Rating feature was already available to some content types such as articles. This change enables other content types to also offer the rating feature.

Per Rachelle's comment in [Ticket 1350](https://jira.mongodb.org/browse/DEVHUB-1350), it is "Rate this announcement" for news & announcements category.