### PR TITLE
Adjust preview to actually delete the deployment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -401,7 +401,7 @@ trigger:
 depends_on: null
 kind: pipeline
 type: kubernetes
-name: clean-up-preview
+name: clean-up-preview 
 
 clone:
   disable: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -401,7 +401,7 @@ trigger:
 depends_on: null
 kind: pipeline
 type: kubernetes
-name: clean-up-preview 
+name: clean-up-preview
 
 clone:
   disable: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -403,6 +403,9 @@ kind: pipeline
 type: kubernetes
 name: clean-up-preview
 
+clone:
+  disable: true
+
 steps:
   - name: uninstall-preview
     image: quay.io/mongodb/drone-helm:v3


### PR DESCRIPTION
The step was trying to clone the branch of the build that was just merged, but since the branch was deleted, it wasn't able to do the clone. This disables the clone step.