### PR TITLE
Remove CDN ingress, replace .staging with new CDN hostname

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,7 @@ steps:
       registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
       repo: devrel/${DRONE_REPO_NAME}
       build_args:
-        - HOST_URL=mongodbcom-cdn.website.staging.corp.mongodb.com
+        - HOST_URL=mongodbcom-cdn.staging.corp.mongodb.com
         - NPM_AUTH
         - NPM_EMAIL
         - REALM_API_URL
@@ -238,7 +238,7 @@ steps:
       registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
       repo: devrel/${DRONE_REPO_NAME}
       build_args:
-        - HOST_URL=mongodbcom-cdn.website.staging.corp.mongodb.com
+        - HOST_URL=mongodbcom-cdn.staging.corp.mongodb.com
         - NPM_AUTH
         - NPM_EMAIL
         - REALM_API_URL

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ When your PR is approved, you can merge it using GitHub's UI. You can choose eit
 
 ### Staging Release
 
-DevCenter is deployed on the Kanopy platform, and when a PR is merged into `main`, the changes will be released through our [drone](https://drone.corp.mongodb.com/mongodb/devcenter/) pipeline. Once the build is completed, the changes are promoted into staging automatically (https://mongodbcom-cdn.website.staging.corp.mongodb.com/developer/). At times, your browser cache will need to be cleared to see the changes immediately.
+DevCenter is deployed on the Kanopy platform, and when a PR is merged into `main`, the changes will be released through our [drone](https://drone.corp.mongodb.com/mongodb/devcenter/) pipeline. Once the build is completed, the changes are promoted into staging automatically (https://mongodbcom-cdn.staging.corp.mongodb.com/developer/). At times, your browser cache will need to be cleared to see the changes immediately.
 
 ### Production Release
 

--- a/environments/staging.yaml
+++ b/environments/staging.yaml
@@ -3,7 +3,7 @@ service:
   targetPort: 3000
 
 env:
-  HOST_URL: mongodbcom-cdn.website.staging.corp.mongodb.com
+  HOST_URL: mongodbcom-cdn.staging.corp.mongodb.com
 
 envSecrets:
   NPM_EMAIL: devcenter-secrets
@@ -48,7 +48,7 @@ resources:
 ingress:
   enabled: true
   path: /developer
-  hosts: ["mongodbcom-cdn.website.staging.corp.mongodb.com","devcenter-frontend.devrel.staging.corp.mongodb.com"]
+  hosts: ["devcenter-frontend.devrel.staging.corp.mongodb.com"]
 
 metrics:
   enabled: true


### PR DESCRIPTION
Updates based on advisory.

Will need to create a KANOPY ticket for them to correct the /developer path configuration.