### PR TITLE
[hotfix] Add line break to card descriptions.

### DIFF
--- a/src/components/card/styles.ts
+++ b/src/components/card/styles.ts
@@ -207,7 +207,7 @@ export const descriptionStyles = (
         WebkitLineClamp: 4,
         WebkitBoxOrient: 'vertical',
         overflow: 'hidden',
-        lineBreak: 'anywhere',
+        lineBreak: 'anywhere' as 'anywhere',
     };
 };
 

--- a/src/components/card/styles.ts
+++ b/src/components/card/styles.ts
@@ -207,6 +207,7 @@ export const descriptionStyles = (
         WebkitLineClamp: 4,
         WebkitBoxOrient: 'vertical',
         overflow: 'hidden',
+        lineBreak: 'anywhere',
     };
 };
 


### PR DESCRIPTION
The long URLs in the video descriptions were causing some weird overflow behavior. 