### PR TITLE
Increase revalidate interval; remove compiler warning

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,10 +17,8 @@ const configVals = {
         domains: ['mongodb-devhub-cms.s3.us-west-1.amazonaws.com'],
     },
     compiler: {
-        styledComponents: true,
-    },
-    experimental: {
         emotion: true,
+        styledComponents: true,
     },
     async headers() {
         return [

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -67,6 +67,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
             pageData: data,
             pageType: pageType,
         },
-        revalidate: 300,
+        revalidate: 900,
     };
 };

--- a/src/pages/author/[...slug].tsx
+++ b/src/pages/author/[...slug].tsx
@@ -1,10 +1,12 @@
 import type { NextPage, GetStaticPaths, GetStaticProps } from 'next';
 import { NextSeo } from 'next-seo';
+import * as Sentry from '@sentry/nextjs';
 import { ParsedUrlQuery } from 'querystring';
-import { getAuthor, getAllAuthors } from '../../service/get-all-authors';
+import { getAuthor } from '../../service/get-all-authors';
+import allAuthorsPreval from '../../service/get-all-authors.preval';
 import { Author, Image } from '../../interfaces/author';
 import { flattenTags } from '../../utils/flatten-tags';
-import { Button, GridLayout, SpeakerLockup, TypographyScale } from '@mdb/flora';
+import { GridLayout, SpeakerLockup, TypographyScale } from '@mdb/flora';
 import Card, { getCardProps } from '../../components/card';
 import { ContentItem } from '../../interfaces/content-item';
 import { Grid } from 'theme-ui';
@@ -266,7 +268,16 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     const { slug } = params as IParams;
     const slugString = '/author/' + slug[0];
 
-    const author: Author | null = await getAuthor(slugString);
+    let author: Author | null;
+    try {
+        author = await getAuthor(slugString);
+    } catch (e) {
+        Sentry.captureException(e);
+        author = allAuthorsPreval.filter(
+            a => a.calculated_slug === slugString
+        )[0];
+    }
+
     if (!author) {
         return {
             notFound: true,
@@ -310,5 +321,5 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         calculated_slug: author.calculated_slug,
     };
 
-    return { props: data, revalidate: 300 };
+    return { props: data, revalidate: 900 };
 };

--- a/src/service/get-all-authors.preval.ts
+++ b/src/service/get-all-authors.preval.ts
@@ -1,0 +1,9 @@
+import preval from 'next-plugin-preval';
+import { getAllAuthors } from './get-all-authors';
+
+async function getData() {
+    const allAuthors = await getAllAuthors();
+    return allAuthors;
+}
+
+export default preval(getData());


### PR DESCRIPTION
- Increases the revalidate interval since on-demand revalidation is active for article pages.
- Pulls from static pre-evaluated data if author page if SSR refetch fails.
- Remove warning for build with SWC by adding `emotion` value to `compiler` option https://nextjs.org/docs/advanced-features/compiler#emotion. 