### PR TITLE
Fix ERR_UNHANDLED_REJECTION

### DIFF
--- a/src/scripts/build-rss-feed.js
+++ b/src/scripts/build-rss-feed.js
@@ -18,6 +18,9 @@ async function buildRssFeed(baseUrl) {
         },
     });
 
+    // We don't use axios here due to a bug in axios where
+    // it cannot always handle responses with long content lengths.
+    // Issue referenced in https://github.com/axios/axios/issues/4806.
     https
         .get(
             `${process.env.REALM_SEARCH_URL}/search_devcenter?s=`,

--- a/src/scripts/build-rss-feed.js
+++ b/src/scripts/build-rss-feed.js
@@ -21,8 +21,8 @@ async function buildRssFeed(baseUrl) {
     const posts = await axios.get(
         `${process.env.REALM_SEARCH_URL}/search_devcenter?s=`,
         {
-            maxContentLength: 1104857600,
-            maxBodyLength: 1104857600,
+            maxContentLength: Infinity,
+            maxBodyLength: Infinity,
         }
     );
 

--- a/src/scripts/build-rss-feed.js
+++ b/src/scripts/build-rss-feed.js
@@ -18,24 +18,23 @@ async function buildRssFeed(baseUrl) {
         },
     });
 
-    const posts = await axios.get(
-        `${process.env.REALM_SEARCH_URL}/search_devcenter?s=`,
-        {
-            maxContentLength: Infinity,
-            maxBodyLength: Infinity,
-        }
-    );
-
-    posts.data.forEach(post => {
-        const url = `${baseUrl}${post.slug}`;
-        feed.addItem({
-            title: post.name,
-            id: url,
-            link: url,
-            description: post.description,
-            date: new Date(post.date),
+    axios
+        .get(`${process.env.REALM_SEARCH_URL}/search_devcenter?s=`)
+        .then(res => {
+            res.data.forEach(post => {
+                const url = `${baseUrl}${post.slug}`;
+                feed.addItem({
+                    title: post.name,
+                    id: url,
+                    link: url,
+                    description: post.description,
+                    date: new Date(post.date),
+                });
+            });
+        })
+        .catch(error => {
+            console.error(error);
         });
-    });
 
     fs.writeFileSync('public/rss.xml', feed.rss2());
 }

--- a/src/scripts/build-rss-feed.js
+++ b/src/scripts/build-rss-feed.js
@@ -19,7 +19,11 @@ async function buildRssFeed(baseUrl) {
     });
 
     const posts = await axios.get(
-        `${process.env.REALM_SEARCH_URL}/search_devcenter?s=`
+        `${process.env.REALM_SEARCH_URL}/search_devcenter?s=`,
+        {
+            maxContentLength: 1104857600,
+            maxBodyLength: 1104857600,
+        }
     );
 
     posts.data.forEach(post => {

--- a/src/scripts/build-rss-feed.js
+++ b/src/scripts/build-rss-feed.js
@@ -19,11 +19,7 @@ async function buildRssFeed(baseUrl) {
     });
 
     const posts = await axios.get(
-        `${process.env.REALM_SEARCH_URL}/search_devcenter?s=`,
-        {
-            maxContentLength: 104857600,
-            maxBodyLength: 104857600,
-        }
+        `${process.env.REALM_SEARCH_URL}/search_devcenter?s=`
     );
 
     posts.data.forEach(post => {


### PR DESCRIPTION
Often, when `yarn build` and tests are run, the build RSS feed script fails on the following error "AxiosError: maxContentLength size of Infinity exceeded" (examples: https://github.com/mongodb/devcenter/runs/7726957248?check_suite_focus=true, https://github.com/mongodb/devcenter/runs/7581091449?check_suite_focus=true, )
```
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

node:internal/process/promises:279
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "AxiosError: maxContentLength size of Infinity exceeded".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
```

This changes the part of my last PR, which was attempted in order to get tests to pass, but doesn't seem to work to resolve the above issue. 
It seems this is an issue that is unresolved in axios (issue 4806), so I am removing it's use and replacing with the built in node.js https module.

