### PR TITLE
[DEVHUB-1395] Add Data Federation product logo

### DIFF
--- a/src/utils/product-to-logo.ts
+++ b/src/utils/product-to-logo.ts
@@ -15,6 +15,7 @@ export const productToLogo: { [key: string]: string } = {
     Charts: 'atlas_charts',
     Triggers: 'atlas_triggers',
     'Data Lake': 'atlas_data_lake',
+    'Data Federation': 'atlas_data_federation',
     API: 'general_features_api',
     'Data Modeling': 'mdb_document_model',
     'Change Streams': 'mdb_change_streams',


### PR DESCRIPTION
[DEVHUB-1395](https://jira.mongodb.org/browse/DEVHUB-1395)

The actual updates to these tutorials will take place in strapi, but we do need this icon before we start that.