### PR TITLE
[DEVHUB-1168] SecondaryNav link spacing fix

### DIFF
--- a/src/components/seconardynavnew/desktop.tsx
+++ b/src/components/seconardynavnew/desktop.tsx
@@ -30,7 +30,7 @@ const StyledSecondaryLinks = {
             null,
             theme.space.inc40,
             theme.space.inc50,
-            theme.space.inc90,
+            theme.space.inc60,
         ],
     },
     whiteSpace: 'nowrap' as 'nowrap',
@@ -50,7 +50,6 @@ const MainLinkStyles = (isActive: boolean) => ({
     float: 'left' as 'left',
     marginRight: ['inc60', 'inc60', 'inc60', 'inc90', 'inc90', 'inc90'],
     fontWeight: 500,
-
     'span.textlink-default-text-class': {
         ...hoverLinkStyles(isActive),
         color: theme.colors.text.default,

--- a/src/components/seconardynavnew/desktop.tsx
+++ b/src/components/seconardynavnew/desktop.tsx
@@ -50,6 +50,7 @@ const MainLinkStyles = (isActive: boolean) => ({
     float: 'left' as 'left',
     marginRight: ['inc60', 'inc60', 'inc60', 'inc90', 'inc90', 'inc90'],
     fontWeight: 500,
+
     'span.textlink-default-text-class': {
         ...hoverLinkStyles(isActive),
         color: theme.colors.text.default,


### PR DESCRIPTION
[[DEVHUB-1168] Secondary nav links are spaced incorrectly (desktop large)](https://jira.mongodb.org/browse/DEVHUB-1168)

On desktop large view, the spacing between links in the SecondaryNav was too large. Reduced from `inc90` to `inc60`

### Before
<img width="1393" alt="Screen Shot 2022-08-24 at 10 31 33 AM" src="https://user-images.githubusercontent.com/110849018/186445411-880d3758-0a84-4db6-b567-92f87edbe77c.png">

### After
<img width="1230" alt="Screen Shot 2022-08-24 at 10 31 18 AM" src="https://user-images.githubusercontent.com/110849018/186445476-debeaaa9-a177-4e0d-ac9f-af4f0eb61198.png">

