### PR TITLE
[DEVHUB-1318]: Improve and Correct the Code Examples Experience

### DIFF
--- a/src/components/article-body/table-of-contents.tsx
+++ b/src/components/article-body/table-of-contents.tsx
@@ -45,7 +45,7 @@ export const TableOfContents = ({
     className?: string;
 }) => {
     return (
-        <div sx={{ paddingLeft: 'inc70' }} className={className}>
+        <div className={className}>
             <TypographyScale variant="heading6">
                 Table of Contents
             </TypographyScale>

--- a/src/components/hero/utils.tsx
+++ b/src/components/hero/utils.tsx
@@ -24,7 +24,7 @@ export const createTopicPageCTAS = (ctas: CTA[]) => {
                               );
                           }
                           if (i === 1) {
-                              return <CTALink {...cta} key={cta.url} />;
+                              return <CTALink {...cta} key={cta.url} />; // TODO: can this be replaced with Flora Link component and we can remove <CTALink /> all together?
                           }
                       })
                     : null}

--- a/src/components/tag-section/tag-section.test.tsx
+++ b/src/components/tag-section/tag-section.test.tsx
@@ -1,4 +1,4 @@
-import { queryByText, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import TagSection from '.';
@@ -10,15 +10,44 @@ const tags: Tag[] = [
     { name: 'Article', type: 'ContentType', slug: '/articles/' },
 ];
 
-test('renders tag section', () => {
-    render(<TagSection tags={tags} />);
+describe('Tag Section', () => {
+    it('renders default tag section', () => {
+        render(<TagSection tags={tags} />);
 
-    const pythonTag = screen.getByText('Python');
-    expect(pythonTag).toHaveAttribute('href', '/developer/languages/python/');
+        const pythonTag = screen.getByText('Python');
+        expect(pythonTag).toHaveAttribute(
+            'href',
+            '/developer/languages/python/'
+        );
 
-    const atlasTag = screen.getByText('Atlas');
-    expect(atlasTag).toHaveAttribute('href', '/developer/products/atlas/');
+        const atlasTag = screen.getByText('Atlas');
+        expect(atlasTag).toHaveAttribute('href', '/developer/products/atlas/');
 
-    // Content type shouldn't show up.
-    expect(screen.queryByText('Article')).toBeNull();
+        // Content type shouldn't show up.
+        expect(screen.queryByText('Article')).toBeNull();
+    });
+
+    it('renders tag section with labels', () => {
+        render(
+            <TagSection
+                withLabels
+                tags={[
+                    ...tags,
+                    {
+                        name: 'Realm',
+                        type: 'L2Product',
+                        slug: '/products/realm/',
+                    },
+                ]}
+            />
+        );
+
+        const langLabel = screen.getByText('Languages');
+        expect(langLabel).toBeInTheDocument();
+        expect(langLabel.nextElementSibling?.childElementCount).toEqual(1); // count rendered tags under category label
+
+        const productLabel = screen.getByText('Products');
+        expect(productLabel).toBeInTheDocument();
+        expect(productLabel.nextElementSibling?.childElementCount).toEqual(2); // L1Product and L2Product types should be grouped together under "Products"
+    });
 });

--- a/src/components/tag-section/tag-section.tsx
+++ b/src/components/tag-section/tag-section.tsx
@@ -1,43 +1,79 @@
-import { Tag } from '@mdb/flora';
+import { Tag as FloraTag, TypographyScale } from '@mdb/flora';
 import { getURLPath } from '../../utils/format-url-path';
+import { Tag as TagType } from '../../interfaces/tag';
 
-import { tagStyles, tagWrapperStyles } from './styles';
+import { filterTags, groupTagsByType } from './utils';
 import { TagSectionProps } from './types';
+import { tagStyles, tagWrapperStyles } from './styles';
+
+const Tag = ({ text, href }: { text: string; href: string | undefined }) => (
+    <FloraTag href={href} variant="small" sx={tagStyles}>
+        {text}
+    </FloraTag>
+);
+
+const renderTagsWithLabel = (fTags: TagType[]) => (
+    <>
+        {groupTagsByType(fTags).map(({ label, tags }) => (
+            <div
+                key={label}
+                sx={{
+                    paddingBottom: 'inc40',
+                    '&:last-of-type': {
+                        paddingBottom: 0,
+                    },
+                }}
+            >
+                <TypographyScale
+                    variant="mono3"
+                    sx={{ textTransform: 'uppercase' }}
+                >
+                    {label}
+                </TypographyScale>
+                <div
+                    sx={{
+                        ...tagWrapperStyles(false),
+                        marginTop: 'inc10',
+                    }}
+                >
+                    {tags.map(({ name, type, slug }) => (
+                        <Tag
+                            key={`${name} ${type}`}
+                            text={name}
+                            href={getURLPath(slug)}
+                        />
+                    ))}
+                </div>
+            </div>
+        ))}
+    </>
+);
 
 const TagSection: React.FunctionComponent<TagSectionProps> = ({
     tags,
+    className = '',
+    withLabels = false,
     disappearOnMobile = false,
-    className,
-}) => (
-    <div
-        sx={tagWrapperStyles(disappearOnMobile)}
-        className={className}
-        data-testid="tag-section"
-    >
-        {tags
-            .filter(
-                tag =>
-                    tag &&
-                    tag.type &&
-                    tag.name &&
-                    tag.slug &&
-                    [
-                        'L1Product',
-                        'L2Product',
-                        'Technology',
-                        'ProgrammingLanguage',
-                    ].includes(tag.type)
-            )
-            .map(tag => (
+}) => {
+    const filteredTags: TagType[] = filterTags(tags);
+
+    return withLabels ? (
+        renderTagsWithLabel(filteredTags)
+    ) : (
+        <div
+            className={className}
+            data-testid="tag-section"
+            sx={tagWrapperStyles(disappearOnMobile)}
+        >
+            {filteredTags.map(tag => (
                 <Tag
                     key={`${tag.name} ${tag.type}`}
+                    text={tag.name}
                     href={getURLPath(tag.slug)}
-                    variant="small"
-                    sx={tagStyles}
-                >
-                    {tag.name}
-                </Tag>
+                />
             ))}
-    </div>
-);
+        </div>
+    );
+};
+
 export default TagSection;

--- a/src/components/tag-section/types.ts
+++ b/src/components/tag-section/types.ts
@@ -2,6 +2,7 @@ import { Tag } from '../../interfaces/tag';
 
 export interface TagSectionProps {
     tags: Tag[];
+    withLabels?: boolean;
     disappearOnMobile?: boolean;
     className?: string;
 }

--- a/src/components/tag-section/utils.ts
+++ b/src/components/tag-section/utils.ts
@@ -1,6 +1,6 @@
 import { Tag } from '../../interfaces/tag';
 
-export type Label = 'Products' | 'Technologies' | 'Languages' | '';
+type Label = 'Products' | 'Technologies' | 'Languages' | '';
 
 interface TagsWithLabel {
     label: Label;

--- a/src/components/tag-section/utils.ts
+++ b/src/components/tag-section/utils.ts
@@ -1,0 +1,59 @@
+import { Tag } from '../../interfaces/tag';
+
+export type Label = 'Products' | 'Technologies' | 'Languages' | '';
+
+interface TagsWithLabel {
+    label: Label;
+    tags: Tag[];
+}
+
+export const filterTags = (tags: Tag[]) =>
+    tags.filter(
+        tag =>
+            tag &&
+            tag.type &&
+            tag.name &&
+            tag.slug &&
+            [
+                'L1Product',
+                'L2Product',
+                'Technology',
+                'ProgrammingLanguage',
+            ].includes(tag.type)
+    );
+
+const mapTypeToLabel = (type: string) => {
+    const mapper: { [key: string]: Label } = {
+        L1Product: 'Products',
+        L2Product: 'Products',
+        Technology: 'Technologies',
+        ProgrammingLanguage: 'Languages',
+        default: '',
+    };
+
+    return mapper[type] || mapper.default;
+};
+
+export const groupTagsByType = (tags: Tag[]) => {
+    const grouped = tags.reduce((acc: TagsWithLabel[], val: Tag) => {
+        const label = mapTypeToLabel(val.type);
+        const existingType = acc.findIndex(type => type.label === label);
+
+        if (existingType !== -1) {
+            acc[existingType] = {
+                ...acc[existingType],
+                tags: [...acc[existingType].tags, val],
+            };
+        } else {
+            acc = [...acc, { label, tags: [val] }];
+        }
+        return acc;
+    }, []);
+
+    // return groupings based on sort order defined in requirements
+    const labelOrder: Label[] = ['Languages', 'Technologies', 'Products'];
+    return grouped.sort(
+        (prev, next) =>
+            labelOrder.indexOf(prev.label) - labelOrder.indexOf(next.label)
+    );
+};

--- a/src/page-templates/main-content-page/content-page-template.tsx
+++ b/src/page-templates/main-content-page/content-page-template.tsx
@@ -393,7 +393,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                     linkIcon="arrow"
                     href={getCtaLinkForVideosOrPodcasts(category)}
                     sx={{
-                        display: 'inline-block',
+                        display: 'block',
                         marginTop: 'inc40',
                     }}
                 >

--- a/src/page-templates/main-content-page/content-page-template.tsx
+++ b/src/page-templates/main-content-page/content-page-template.tsx
@@ -40,7 +40,6 @@ import { getPlaceHolderImage } from '../../utils/get-place-holder-thumbnail';
 import Image from 'next/image';
 import { getCardProps, thumbnailLoader } from '../../components/card/utils';
 import parse from 'html-react-parser';
-import CTALink from '../../components/hero/CTALink';
 import { DocumentBody } from '../../components/article-body/document-body';
 import SeriesCard from '../../components/series-card';
 import { Grid, ThemeUICSSObject } from 'theme-ui';
@@ -361,7 +360,8 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                     )}
                 </div>
                 {!previewMode && ratingSection}
-                {(githubUrl || liveSiteUrl) &&
+                {isCodeExample &&
+                    (githubUrl || liveSiteUrl) &&
                     renderExternalExamples({
                         marginTop: 'inc50',
                         marginBottom: ['', null, null, '-inc40'], // negates marginTop from contentBody since externalExamples might not always be present
@@ -389,16 +389,20 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                 </TypographyScale>
             )}
             {vidOrPod && (
-                <CTALink
-                    customCSS={{
+                <Link
+                    linkIcon="arrow"
+                    href={getCtaLinkForVideosOrPodcasts(category)}
+                    sx={{
+                        display: 'inline-block',
                         marginTop: 'inc40',
                     }}
-                    text={getCtaTextForVideosOrPodcasts(category)}
-                    url={getCtaLinkForVideosOrPodcasts(category)}
-                />
+                >
+                    {getCtaTextForVideosOrPodcasts(category)}
+                </Link>
             )}
             {!vidOrPod && <DocumentBody content={contentAst} />}
-            {(githubUrl || liveSiteUrl) &&
+            {isCodeExample &&
+                (githubUrl || liveSiteUrl) &&
                 renderExternalExamples({ marginTop: 'inc40' })}
         </div>
     );

--- a/src/page-templates/main-content-page/content-page-template.tsx
+++ b/src/page-templates/main-content-page/content-page-template.tsx
@@ -6,7 +6,7 @@ import { CollectionType } from '../../types/collection-type';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import getConfig from 'next/config';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import axios from 'axios';
 import FeedbackModal, {
     feedbackModalStages,
@@ -25,6 +25,7 @@ import {
     ESystemIconNames,
     GridLayout,
     HorizontalRule,
+    Link,
     SideNav,
     TypographyScale,
 } from '@mdb/flora';
@@ -42,7 +43,7 @@ import parse from 'html-react-parser';
 import CTALink from '../../components/hero/CTALink';
 import { DocumentBody } from '../../components/article-body/document-body';
 import SeriesCard from '../../components/series-card';
-import { Grid } from 'theme-ui';
+import { Grid, ThemeUICSSObject } from 'theme-ui';
 import Card from '../../components/card';
 import { NextSeo } from 'next-seo';
 import {
@@ -186,6 +187,8 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
         -1
     );
 
+    const isCodeExample = category === 'Code Example';
+
     const authorsToDisplay = parseAuthorsToAuthorLockup(authors);
 
     const hasRequestContentFlow =
@@ -221,6 +224,44 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
         >
             <span>Rate this {normalizeCategory(category)}</span>
             <ContentRating stars={ratingStars} onRate={onRate} />
+        </div>
+    );
+
+    const renderExternalExamples = (styles: ThemeUICSSObject = {}) => (
+        <div
+            sx={{
+                display: 'flex',
+                columnGap: [0, 'inc70'],
+                flexDirection: ['column', 'row'],
+                alignItems: ['start', 'center'],
+                ...styles,
+            }}
+        >
+            {githubUrl && (
+                <Button
+                    hasIcon
+                    href={githubUrl}
+                    target="_blank"
+                    variant="secondary"
+                    iconName={ESystemIconNames.EXTERNAL}
+                    sx={{
+                        width: 'auto',
+                    }}
+                >
+                    View Code
+                </Button>
+            )}
+            {liveSiteUrl && (
+                <Link
+                    linkIcon="arrow"
+                    href={liveSiteUrl}
+                    sx={{
+                        marginTop: ['inc30', 0],
+                    }}
+                >
+                    Try it
+                </Link>
+            )}
         </div>
     );
 
@@ -265,7 +306,14 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                             </TypographyScale>
                         )}
                     </div>
-                    <div sx={{ gridArea: 'tags' }}>
+                    <div
+                        sx={{
+                            gridArea: 'tags',
+                            ...(isCodeExample && {
+                                display: ['flex', null, null, null, 'none'],
+                            }),
+                        }}
+                    >
                         {tags && <TagSection tags={tags} />}
                     </div>
                     {codeType && (
@@ -285,7 +333,6 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                     )}
                 </div>
             </div>
-
             <div sx={middleSectionStyles}>
                 <div sx={imageStyles}>
                     {category === 'Podcast' && (
@@ -314,6 +361,11 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                     )}
                 </div>
                 {!previewMode && ratingSection}
+                {(githubUrl || liveSiteUrl) &&
+                    renderExternalExamples({
+                        marginTop: 'inc50',
+                        marginBottom: ['', null, null, '-inc40'], // negates marginTop from contentBody since externalExamples might not always be present
+                    })}
             </div>
         </>
     );
@@ -346,26 +398,8 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                 />
             )}
             {!vidOrPod && <DocumentBody content={contentAst} />}
-            <div
-                sx={{
-                    display: [null, 'flex'],
-                    columnGap: [0, 'inc70'],
-                    marginTop: ['inc40'],
-                }}
-            >
-                {githubUrl && (
-                    <Button
-                        href={githubUrl}
-                        target="_blank"
-                        variant="secondary"
-                        hasIcon
-                        iconName={ESystemIconNames.HAMBURGER}
-                    >
-                        View Code
-                    </Button>
-                )}
-                {liveSiteUrl && <CTALink text="Try it" url={liveSiteUrl} />}
-            </div>
+            {(githubUrl || liveSiteUrl) &&
+                renderExternalExamples({ marginTop: 'inc40' })}
         </div>
     );
 
@@ -442,12 +476,11 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
         handle: seo?.twitter_creator,
         site: seo?.twitter_site,
     };
-    const canonicalUrl = seo?.canonical_url
-        ? seo?.canonical_url
-        : publicRuntimeConfig.absoluteBasePath + router.asPath;
-    const metaDescription = seo?.meta_description
-        ? seo.meta_description
-        : publicRuntimeConfig.pageDescriptions['/'];
+    const canonicalUrl =
+        seo?.canonical_url ||
+        publicRuntimeConfig.absoluteBasePath + router.asPath;
+    const metaDescription =
+        seo?.meta_description || publicRuntimeConfig.pageDescriptions['/'];
 
     return (
         <>
@@ -503,8 +536,20 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                                 display: ['none', null, null, null, 'block'],
                                 gridColumn: '10 /span 3',
                                 gridRow: '3 / 5',
+                                paddingLeft: 'inc70',
                             }}
                         >
+                            {isCodeExample && tags && (
+                                <div sx={{ marginBottom: 'inc90' }}>
+                                    <TypographyScale
+                                        variant="heading6"
+                                        sx={{ marginBottom: 'inc30' }}
+                                    >
+                                        Technologies Used
+                                    </TypographyScale>
+                                    <TagSection withLabels tags={tags} />
+                                </div>
+                            )}
                             {headingNodes.length > 0 && (
                                 <TableOfContents
                                     headingNodes={headingNodes}


### PR DESCRIPTION
Ticket: https://jira.mongodb.org/browse/DEVHUB-1318

Scope
- Adds a 2nd group of CTA's for Code Example content types to view code on github or try out live site.
- Moves tags to aside view on desktop with labeled grouping -> falls back to original placement of tags below Author Info
- Adds unit test for rendering with labels to `tag-section` 