### PR TITLE
[DEVHUB-1234] Fix Breadcrumb/Pill boldness issue in Safari

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -29,7 +29,7 @@ const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({
                         {/* The negative margin is to offset the added 3px from the letter-spacing on the last character that Flora adds.*/}
                         <Eyebrow
                             customElement="span"
-                            sx={{ marginRight: '-3px' }}
+                            sx={{ marginRight: '-3px', fontWeight: 'normal' }}
                         >
                             {text}
                         </Eyebrow>

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -29,7 +29,7 @@ const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({
                         {/* The negative margin is to offset the added 3px from the letter-spacing on the last character that Flora adds.*/}
                         <Eyebrow
                             customElement="span"
-                            sx={{ marginRight: '-3px', fontWeight: 'normal' }}
+                            sx={{ marginRight: '-3px', fontWeight: '500' }}
                         >
                             {text}
                         </Eyebrow>

--- a/src/components/card/styles.ts
+++ b/src/components/card/styles.ts
@@ -22,7 +22,7 @@ export const pillStyles = (pillCategory: PillCategory) => ({
     px: ['inc30', null, null, 'inc40'],
     py: ['inc10', null, null, 'inc20'],
     fontSize: ['9px', null, null, 'inc00'],
-    fontWeight: 'normal',
+    fontWeight: '500',
     letterSpacing: ['2.5px', null, null, '3px'],
 });
 

--- a/src/components/card/styles.ts
+++ b/src/components/card/styles.ts
@@ -22,6 +22,7 @@ export const pillStyles = (pillCategory: PillCategory) => ({
     px: ['inc30', null, null, 'inc40'],
     py: ['inc10', null, null, 'inc20'],
     fontSize: ['9px', null, null, 'inc00'],
+    fontWeight: 'normal',
     letterSpacing: ['2.5px', null, null, '3px'],
 });
 


### PR DESCRIPTION
[[DEVHUB-1234] Text too bold in Safari](https://jira.mongodb.org/browse/DEVHUB-1234)

The text in safari for breadcrumbs/pills was bold compared to the same text on Chrome:
<img width="1680" alt="Screen Shot 2022-08-25 at 9 47 54 AM" src="https://user-images.githubusercontent.com/110849018/186682293-8def3dc6-03a8-456e-a9f2-49851ba1fabd.png">

Explicitly setting a font weight seems to fix this issue:
<img width="1682" alt="Screen Shot 2022-08-25 at 9 48 11 AM" src="https://user-images.githubusercontent.com/110849018/186682439-e285ba8b-69a6-46cd-8f8a-95e8455160f1.png">

