### PR TITLE
[FIX] Don't include current article in "more in this series"

### DIFF
--- a/src/components/series-card/series-card.test.tsx
+++ b/src/components/series-card/series-card.test.tsx
@@ -2,71 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import SeriesCard from '.';
-import { PillCategory } from '../../types/pill-category';
 import { Series } from '../../interfaces/series';
-import { SeriesEntry } from '../../interfaces/series-entry';
-
-// const series = {
-//     title: 'Cool Atlas Stuff',
-//     content: [
-//         {
-//             authors: ['Farah Appleseed'],
-//             category: 'Article' as PillCategory,
-//             image: {
-//                 alt: 'thumbnail',
-//                 url: 'https://mongodb-devhub-cms.s3.us-west-1.amazonaws.com/ATF_720x720_17fd9d891f.png',
-//             },
-//             title: 'This is 101 article',
-//             description: 'This is my first article',
-//             contentDate: new Date().toDateString(),
-//             tags: ['Atlas Data Lake', 'Realm Studio', 'Netlify', 'GITHUB'],
-//             featured: true,
-//             slug: 'product/atlas/a1',
-//         },
-//         {
-//             authors: ['Farah Appleseed'],
-//             category: 'Article' as PillCategory,
-//             image: {
-//                 alt: 'thumbnail',
-//                 url: 'https://mongodb-devhub-cms.s3.us-west-1.amazonaws.com/ATF_720x720_17fd9d891f.png',
-//             },
-//             title: 'This is 102 article',
-//             description: 'This is my second article',
-//             contentDate: new Date().toDateString(),
-//             tags: ['Atlas Data Lake', 'Realm Studio', 'Netlify', 'GITHUB'],
-//             featured: false,
-//             slug: 'product/atlas/a2',
-//         },
-//         {
-//             authors: ['Farah Appleseed'],
-//             category: 'Article' as PillCategory,
-//             image: {
-//                 alt: 'thumbnail',
-//                 url: 'https://mongodb-devhub-cms.s3.us-west-1.amazonaws.com/ATF_720x720_17fd9d891f.png',
-//             },
-//             title: 'This is 103 article',
-//             description: 'This is my third article',
-//             contentDate: new Date().toDateString(),
-//             tags: ['Atlas Data Lake', 'Realm Studio', 'Netlify', 'GITHUB'],
-//             featured: false,
-//             slug: 'product/atlas/a3',
-//         },
-//         {
-//             authors: ['Farah Appleseed'],
-//             category: 'Article' as PillCategory,
-//             image: {
-//                 alt: 'thumbnail',
-//                 url: 'https://mongodb-devhub-cms.s3.us-west-1.amazonaws.com/ATF_720x720_17fd9d891f.png',
-//             },
-//             title: 'This is 104 article',
-//             description: 'This is my fourth article',
-//             contentDate: new Date().toDateString(),
-//             tags: ['Atlas Data Lake', 'Realm Studio', 'Netlify', 'GITHUB'],
-//             featured: false,
-//             slug: 'product/atlas/a4',
-//         },
-//     ],
-// };
 
 const series: Series = {
     title: 'Cool Atlas Stuff',
@@ -96,13 +32,7 @@ const lastSlug = 'product/atlas/a4';
 const lastTitle = 'This is 104 article';
 
 test("renders series with with piece that isn't last in series", () => {
-    render(
-        <SeriesCard
-            series={series}
-            currentSlug={notLastSlug}
-            currentTitle={notLastTitle}
-        />
-    );
+    render(<SeriesCard series={series} currentTitle={notLastTitle} />);
 
     expect(screen.getByText('This is part of a series')).toBeInTheDocument();
     expect(screen.getByText(series.title)).toBeInTheDocument();
@@ -112,7 +42,7 @@ test("renders series with with piece that isn't last in series", () => {
     ).toHaveLength(2);
     expect(screen.getByRole('link', { name: 'Continue' })).toBeInTheDocument();
     series.seriesEntry.forEach(piece => {
-        if (piece.calculatedSlug !== notLastSlug) {
+        if (piece.title !== notLastTitle) {
             expect(
                 screen
                     .getAllByRole('listitem')
@@ -123,13 +53,7 @@ test("renders series with with piece that isn't last in series", () => {
 });
 
 test('renders series with piece that is last in series', () => {
-    render(
-        <SeriesCard
-            series={series}
-            currentSlug={lastSlug}
-            currentTitle={lastTitle}
-        />
-    );
+    render(<SeriesCard series={series} currentTitle={lastTitle} />);
 
     expect(screen.getByText('This is part of a series')).toBeInTheDocument();
     expect(screen.getByText(series.title)).toBeInTheDocument();

--- a/src/components/series-card/series-card.tsx
+++ b/src/components/series-card/series-card.tsx
@@ -27,20 +27,21 @@ const findNextInSeries = (
 
 const SeriesCard: React.FunctionComponent<SeriesCardProps> = ({
     series,
-    currentSlug,
     currentTitle,
     className,
 }) => {
     const nextInSeries = findNextInSeries(series.seriesEntry, currentTitle);
 
-    const listItems = series.seriesEntry.map(({ title, calculatedSlug }) => ({
-        text: title,
-        url: calculatedSlug,
-    }));
+    const listItems = series.seriesEntry
+        .filter(({ title }) => title !== currentTitle)
+        .map(({ title, calculatedSlug }) => ({
+            text: title,
+            url: calculatedSlug,
+        }));
 
     return (
         <div sx={seriesCardStyles} className={className}>
-            <Eyebrow sx={{ marginBottom: 'inc20' }}>
+            <Eyebrow sx={{ marginBottom: 'inc20', fontWeight: '500' }}>
                 This is part of a series
             </Eyebrow>
             <TypographyScale

--- a/src/components/series-card/types.ts
+++ b/src/components/series-card/types.ts
@@ -2,7 +2,6 @@ import { Series } from '../../interfaces/series';
 
 export interface SeriesCardProps {
     series: Series;
-    currentSlug: string;
     currentTitle: string;
     className?: string;
 }

--- a/src/page-templates/main-content-page/content-page-template.tsx
+++ b/src/page-templates/main-content-page/content-page-template.tsx
@@ -392,13 +392,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                     </div>
                 )}
             </div>
-            {series && (
-                <SeriesCard
-                    series={series}
-                    currentSlug={slug}
-                    currentTitle={title}
-                />
-            )}
+            {series && <SeriesCard series={series} currentTitle={title} />}
             <div>
                 <TypographyScale
                     variant="heading5"


### PR DESCRIPTION
Just noticed we were including the current article in the article series card. Also fixed the safari mono boldness issue here.

https://www.mongodb.com/developer/products/realm/realm-data-types/

**Before:**
<img width="795" alt="Screen Shot 2022-08-25 at 10 56 05 AM" src="https://user-images.githubusercontent.com/46664803/186700002-9e3ff52d-3693-48f9-9cc9-672ff6e3875e.png">

**After:**
<img width="746" alt="Screen Shot 2022-08-25 at 10 56 16 AM" src="https://user-images.githubusercontent.com/46664803/186700011-6e8cc8aa-2889-4a81-ab18-9296669dae9f.png">

