### PR TITLE
[DEVHUB-1431] Fix having to click twice for videos to play

### DIFF
--- a/src/components/article-body/body-components/video-embed.tsx
+++ b/src/components/article-body/body-components/video-embed.tsx
@@ -36,7 +36,7 @@ export const VideoEmbed = ({
 }: {
     argument: Argument[];
     name: string;
-    thumbnail: string;
+    thumbnail?: string;
 }) => {
     const videoId = argument[0].value;
     const value = getVideoUrl(provider, videoId);

--- a/src/page-templates/main-content-page/content-page-template.tsx
+++ b/src/page-templates/main-content-page/content-page-template.tsx
@@ -297,7 +297,6 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                         <VideoEmbed
                             argument={[{ value: parseUndefinedValue(videoId) }]}
                             name="youtube"
-                            thumbnail={getPlaceHolderImage(image?.url)}
                         />
                     )}
                     {!vidOrPod && (


### PR DESCRIPTION
[[DEVHUB-1431] Must click "play" twice for a video to play](https://jira.mongodb.org/browse/DEVHUB-1431)

Before, there was a thumbnail that had to be clicked on videos:
<img width="889" alt="Screen Shot 2022-08-26 at 10 11 15 AM" src="https://user-images.githubusercontent.com/110849018/186923007-eea8a05b-cc1f-45e9-aab8-7f9cbecdaf4c.png">

Now, it displays the video directly from the provider:
<img width="886" alt="Screen Shot 2022-08-26 at 10 10 27 AM" src="https://user-images.githubusercontent.com/110849018/186923104-5b7873c6-f10f-48f5-a1e5-25fe96a33b41.png">

