### PR TITLE
[DEVHUB-1175] Secondary Nav Mobile "Topics" expanded and not expandable

### DIFF
--- a/src/components/seconardynavnew/mobile.test.tsx
+++ b/src/components/seconardynavnew/mobile.test.tsx
@@ -14,10 +14,6 @@ const tags: Tag[] = [
 test('renders mobile dropdown', () => {
     render(<Mobile />);
 
-    // Hidden by default.
-    const languagesTitle = screen.queryByText('Languages');
-    expect(languagesTitle).toBeNull();
-
     userEvent.click(screen.getByTitle('chevron-down'));
 
     // See articles.

--- a/src/components/seconardynavnew/mobile.test.tsx
+++ b/src/components/seconardynavnew/mobile.test.tsx
@@ -23,9 +23,6 @@ test('renders mobile dropdown', () => {
         '/developer/articles/'
     );
 
-    const topics = screen.getByText('Topics');
-    topics.click();
-
     const allTopics = screen.getByText('All Topics');
     expect(
         allTopics.parentElement?.parentElement?.parentElement

--- a/src/components/seconardynavnew/mobile.tsx
+++ b/src/components/seconardynavnew/mobile.tsx
@@ -320,7 +320,6 @@ const MobileView = () => {
                     <SecondaryLinksList key={name}>
                         {dropDownItems?.length ? (
                             <>
-                                {' '}
                                 {/* Level 1 */}
                                 <div sx={DropDownStyles}>
                                     <div>{name}</div>

--- a/src/components/seconardynavnew/mobile.tsx
+++ b/src/components/seconardynavnew/mobile.tsx
@@ -20,47 +20,6 @@ import {
 import { DropDownItem, DropDownItem2 } from './dropdown-menu';
 import { getURLPath } from '../../utils/format-url-path';
 
-const DropDownButton = ({
-    text,
-    dropDownItems,
-}: {
-    text: string;
-    dropDownItems: DropDownItem[];
-}) => {
-    const [isOpen, setIsOpen] = useState(false);
-    const onClickShowMenu = () => {
-        setIsOpen(!isOpen);
-    };
-
-    return (
-        <>
-            <div sx={DropDownStyles}>
-                {/* Level 1 */}
-                <div onClick={onClickShowMenu}>
-                    {text}
-                    {!isOpen && (
-                        <SystemIcon
-                            sx={plusOrMinusStylesForDropDowns}
-                            name={ESystemIconNames.PLUS}
-                            size="small"
-                            color="success"
-                        />
-                    )}
-                    {isOpen && (
-                        <SystemIcon
-                            sx={plusOrMinusStylesForDropDowns}
-                            name={ESystemIconNames.MINUS}
-                            size="small"
-                            color="success"
-                        />
-                    )}
-                </div>
-            </div>
-            {isOpen && <DropDownMenu items={dropDownItems} />}
-        </>
-    );
-};
-
 const SubNavLink = ({ name, dropDownItems, path, all }: DropDownItem) => {
     const [isOpen, setIsOpen] = useState(false);
     const onClickShowMenu = () => {
@@ -360,10 +319,14 @@ const MobileView = () => {
                 {secondaryNavData.map(({ name, slug, dropDownItems }) => (
                     <SecondaryLinksList key={name}>
                         {dropDownItems?.length ? (
-                            <DropDownButton
-                                text={name}
-                                dropDownItems={dropDownItems}
-                            />
+                            <>
+                                {' '}
+                                {/* Level 1 */}
+                                <div sx={DropDownStyles}>
+                                    <div>{name}</div>
+                                </div>
+                                <DropDownMenu items={dropDownItems} />
+                            </>
                         ) : (
                             <>
                                 <div sx={DropDownStyles}>


### PR DESCRIPTION
[[DEVHUB-1175] Secondary Nav: Mobile - "Topics" should be expanded, and not expandable](https://jira.mongodb.org/browse/DEVHUB-1175)

### Before
<img width="721" alt="Screen Shot 2022-08-29 at 9 43 45 AM" src="https://user-images.githubusercontent.com/110849018/187215486-27c4b8b2-1059-46ba-8bab-2e350fecf07b.png">


### After
<img width="715" alt="Screen Shot 2022-08-29 at 9 42 05 AM" src="https://user-images.githubusercontent.com/110849018/187215495-372f4aee-e95e-444e-9ff2-669a1ee1de1e.png">

