### PR TITLE
Upgrade helm web-app chart to 4.12.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,7 +80,7 @@ steps:
     image: quay.io/mongodb/drone-helm:v3
     settings:
       chart: mongodb/web-app
-      chart_version: 4.11.3
+      chart_version: 4.12.0
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: devrel
       release: devcenter-frontend
@@ -170,7 +170,7 @@ steps:
     image: quay.io/mongodb/drone-helm:v3
     settings:
       chart: mongodb/web-app
-      chart_version: 4.11.3
+      chart_version: 4.12.0
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: devrel
       release: devcenter-frontend
@@ -384,7 +384,7 @@ steps:
     settings:
       mode: upgrade # Not sure why we have to set this only here, but we do.
       chart: mongodb/web-app
-      chart_version: 4.7.3
+      chart_version: 4.12.0
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: devrel
       release: devcenter-frontend-preview-${number}


### PR DESCRIPTION
This is needed based on an advisory from the Kanopy channel.