### PR TITLE
[DEVHUB-1171] Secondary Nav Spacing Fixes

### DIFF
--- a/src/components/seconardynavnew/desktop.tsx
+++ b/src/components/seconardynavnew/desktop.tsx
@@ -26,7 +26,7 @@ const StyledSecondaryLinks: ThemeUIStyleObject | undefined = {
     padding: 0,
     margin: 0,
     overflow: 'visible',
-    'li.secondary-nav-link:not(:last-child)': {
+    '> li:not(:last-child)': {
         marginRight: [
             null,
             null,

--- a/src/components/seconardynavnew/dropdown-menu.tsx
+++ b/src/components/seconardynavnew/dropdown-menu.tsx
@@ -171,7 +171,8 @@ const SubNavLink = ({ name, slug, dropDownItems, path, all }: DropDownItem) => {
                     href={getURLPath('topics')}
                     sx={{
                         marginTop: '25px',
-                        padding: '16px 48px',
+                        px: 'inc70',
+                        py: 'inc30',
                         '&:hover': {
                             color: 'initial!important',
                         },

--- a/src/components/seconardynavnew/dropdown-menu.tsx
+++ b/src/components/seconardynavnew/dropdown-menu.tsx
@@ -76,31 +76,15 @@ const DropDownMenuList = styled.ul`
     }
 `;
 
-const SubLinks = styled.ul`
-    list-style-type: none;
-    padding: 0;
-
-    ul {
-        list-style-type: none;
-        padding: 0;
-        margin-top: ${theme.space.inc30};
-
-        > li {
-            position: relative;
-
-            &:last-child {
-                display: none;
-            }
-        }
-    }
-
-    @media only screen and (min-width: ${theme.sizes.breakpoint.large}) {
-        display: grid;
-        grid-column-gap: ${theme.space.inc50};
-        grid-template-columns: repeat(3, 1fr);
-        margin-right: ${theme.space.inc30};
-    }
-`;
+const subLinkStyles = {
+    listStyleType: 'none',
+    padding: 0,
+    marginTop: 'inc30',
+    display: [null, null, null, 'grid'],
+    gridColumnGap: [null, null, null, 'inc70', 'inc90'],
+    gridTemplateColumns: [null, null, null, 'repeat(3, 1fr)'],
+    marginRight: [null, null, null, 'inc90', 'inc130'],
+};
 
 const SubNavLink = ({ name, slug, dropDownItems, path, all }: DropDownItem) => {
     return (
@@ -121,10 +105,19 @@ const SubNavLink = ({ name, slug, dropDownItems, path, all }: DropDownItem) => {
             )}
             {dropDownItems && (
                 <>
-                    <SubLinks>
+                    <ul sx={subLinkStyles}>
                         {dropDownItems?.map(
                             ({ name, slug, dropDownItems, l1Product }) => (
-                                <li key={name}>
+                                <li
+                                    sx={{
+                                        position: 'relative',
+
+                                        '&:last-child': {
+                                            display: 'none',
+                                        },
+                                    }}
+                                    key={name}
+                                >
                                     <a
                                         href={getURLPath(slug)}
                                         sx={{
@@ -156,7 +149,7 @@ const SubNavLink = ({ name, slug, dropDownItems, path, all }: DropDownItem) => {
                                 </li>
                             )
                         )}
-                    </SubLinks>
+                    </ul>
                     {all && (
                         <FloraLink
                             sx={{

--- a/src/components/seconardynavnew/dropdown-menu.tsx
+++ b/src/components/seconardynavnew/dropdown-menu.tsx
@@ -171,6 +171,7 @@ const SubNavLink = ({ name, slug, dropDownItems, path, all }: DropDownItem) => {
                     href={getURLPath('topics')}
                     sx={{
                         marginTop: '25px',
+                        padding: '16px 48px',
                         '&:hover': {
                             color: 'initial!important',
                         },


### PR DESCRIPTION
[[DEVHUB-1171] Secondary Nav 3 column spacing incorrect (small columns)](https://jira.mongodb.org/browse/DEVHUB-1171)

Previously there was incorrect spacing between columns and within the "All Topics" button of the secondary nav in desktop 
 view. This PR fixes these issues, and cleans up some of the styling logic.

### Before
<img width="2056" alt="Screen Shot 2022-08-30 at 1 40 53 PM" src="https://user-images.githubusercontent.com/110849018/187506999-6547e310-32c0-44e3-8dd1-0ae7445ec362.png">


### After
<img width="2056" alt="Screen Shot 2022-08-30 at 1 39 40 PM" src="https://user-images.githubusercontent.com/110849018/187507008-4341a484-960e-4b9d-b706-e486f99d813b.png">
