### PR TITLE
[DEVHUB-1247] Set custom cookie names in next-auth config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,7 +34,7 @@ const configVals = {
                 headers: [
                     {
                         key: 'Cache-Control',
-                        value: 'max-age=3600',
+                        value: 'max-age=900',
                     },
                     {
                         key: 'Strict-Transport-Security',

--- a/next.config.js
+++ b/next.config.js
@@ -34,7 +34,7 @@ const configVals = {
                 headers: [
                     {
                         key: 'Cache-Control',
-                        value: 'max-age=900',
+                        value: 'max-age=3600',
                     },
                     {
                         key: 'Strict-Transport-Security',

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -3,8 +3,8 @@ import type { NextAuthOptions } from 'next-auth';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import NextAuth from 'next-auth';
 
-const cookiePrefix = 'mdbdc_';
 const useSecureCookies = process.env.NEXTAUTH_URL?.startsWith('https://');
+const cookiePrefix = useSecureCookies ? '__Secure-mdbdc_' : 'mdbdc_';
 
 export const nextAuthOptions: NextAuthOptions = {
     cookies: {

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -3,7 +3,28 @@ import type { NextAuthOptions } from 'next-auth';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import NextAuth from 'next-auth';
 
+const cookiePrefix = 'mdbdc_';
+const useSecureCookies = process.env.NEXTAUTH_URL?.startsWith('https://');
+
 export const nextAuthOptions: NextAuthOptions = {
+    cookies: {
+        pkceCodeVerifier: {
+            name: `${cookiePrefix}next-auth.pkce.code_verifier`,
+            options: {
+                sameSite: 'lax',
+                path: '/',
+                secure: useSecureCookies,
+            },
+        },
+        state: {
+            name: `${cookiePrefix}next-auth.state`,
+            options: {
+                sameSite: 'lax',
+                path: '/',
+                secure: useSecureCookies,
+            },
+        },
+    },
     providers: [
         OktaProvider({
             clientId: process.env.OKTA_CLIENT_ID as string,


### PR DESCRIPTION
Overrides cookie names for next-auth.pkce.code_verifier and next-auth.state with custom set names. If secure cookies are enabled, __Session is prepended.

This was needed to get the staging CDN to work properly given the existing key list Kanopy configured.