### PR TITLE
[DEVHUB-1125] Add Sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+    siteUrl: process.env.SITE_URL || 'https://mongodb.com/',
+    generateRobotsTxt: true, // (optional)
+    // ...other options
+};

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,0 @@
-/** @type {import('next-sitemap').IConfig} */
-module.exports = {
-    siteUrl: process.env.SITE_URL || 'https://mongodb.com/',
-    generateRobotsTxt: true, // (optional)
-    // ...other options
-};

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "next-auth": "4.10.3",
         "next-plugin-preval": "1.2.4",
         "next-seo": "5.4.0",
-        "next-sitemap": "^3.1.21",
+        "next-sitemap": "3.1.21",
         "pino": "8.0.0",
         "pluralize": "8.0.0",
         "prom-client": "14.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "scripts": {
         "dev": "next dev",
         "build": "next build",
-        "postbuild": "next-sitemap --config next-sitemap.config.js",
         "build:analyze": "ANALYZE=true next build",
         "start": "next start",
         "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "scripts": {
         "dev": "next dev",
         "build": "next build",
+        "postbuild": "next-sitemap --config next-sitemap.config.js",
         "build:analyze": "ANALYZE=true next build",
         "start": "next start",
         "lint": "next lint",
@@ -41,6 +42,7 @@
         "next-auth": "4.10.3",
         "next-plugin-preval": "1.2.4",
         "next-seo": "5.4.0",
+        "next-sitemap": "^3.1.21",
         "pino": "8.0.0",
         "pluralize": "8.0.0",
         "prom-client": "14.0.1",

--- a/src/pages/sitemap/sitemap-index.xml.ts
+++ b/src/pages/sitemap/sitemap-index.xml.ts
@@ -2,18 +2,16 @@ import fs from 'fs';
 import path from 'path';
 import { getServerSideSitemap } from 'next-sitemap';
 import { GetServerSideProps } from 'next';
-import { getAllContentItems } from '../../service/get-all-content';
+import allContentPreval from '../../service/get-all-content.preval';
 import { getTopicPagePathMappings } from '../../service/get-topic-paths';
 
-const DEVCENTER_URL =
-    process.env.DEVCENTER_URL || 'https://mongodb.com/developer';
+const DEVCENTER_URL = 'https://mongodb.com/developer';
 
 export const getServerSideProps: GetServerSideProps = async context => {
     const curDate = new Date().toISOString();
 
     const { topicContentTypePaths, topicPaths } =
         await getTopicPagePathMappings();
-    const allContent = await getAllContentItems();
 
     const staticPages = fs
         .readdirSync('src/pages', { withFileTypes: true })
@@ -38,7 +36,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
         priority: 0.7,
     }));
 
-    const contentPages = allContent.map(({ slug, contentDate }) => ({
+    const contentPages = allContentPreval.map(({ slug, contentDate }) => ({
         loc: `${DEVCENTER_URL}/${slug}`,
         lastmod: contentDate || curDate,
         priority: 0.5,

--- a/src/pages/sitemap/sitemap-index.xml.ts
+++ b/src/pages/sitemap/sitemap-index.xml.ts
@@ -5,7 +5,8 @@ import { GetServerSideProps } from 'next';
 import { getAllContentItems } from '../../service/get-all-content';
 import { getTopicPagePathMappings } from '../../service/get-topic-paths';
 
-const SITE_URL = process.env.SITE_URL || 'https://mongodb.com/developer';
+const DEVCENTER_URL =
+    process.env.DEVCENTER_URL || 'https://mongodb.com/developer';
 
 export const getServerSideProps: GetServerSideProps = async context => {
     const curDate = new Date().toISOString();
@@ -23,7 +24,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
                 !dirent.name.includes('index')
         )
         .map(dirent => ({
-            loc: `${SITE_URL}/${path.parse(dirent.name).name}`,
+            loc: `${DEVCENTER_URL}/${path.parse(dirent.name).name}`,
             lastmod: curDate,
             priority: 1.0,
         }));
@@ -32,13 +33,13 @@ export const getServerSideProps: GetServerSideProps = async context => {
         ...Object.keys(topicContentTypePaths),
         ...Object.keys(topicPaths),
     ].map(path => ({
-        loc: `${SITE_URL}/${path}`,
+        loc: `${DEVCENTER_URL}/${path}`,
         lastmod: curDate,
         priority: 0.7,
     }));
 
     const contentPages = allContent.map(({ slug, contentDate }) => ({
-        loc: `${SITE_URL}/${slug}`,
+        loc: `${DEVCENTER_URL}/${slug}`,
         lastmod: contentDate || curDate,
         priority: 0.5,
     }));

--- a/src/pages/sitemap/sitemap-index.xml.ts
+++ b/src/pages/sitemap/sitemap-index.xml.ts
@@ -50,4 +50,5 @@ export const getServerSideProps: GetServerSideProps = async context => {
     ]);
 };
 
-export default function SitemapDynamic() {}
+const Sitemap = () => {};
+export default Sitemap;

--- a/src/pages/sitemap/sitemap-index.xml.ts
+++ b/src/pages/sitemap/sitemap-index.xml.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+import { getServerSideSitemap } from 'next-sitemap';
+import { GetServerSideProps } from 'next';
+import { getAllContentItems } from '../../service/get-all-content';
+import { getTopicPagePathMappings } from '../../service/get-topic-paths';
+
+const SITE_URL = process.env.SITE_URL || 'https://mongodb.com/developer';
+
+export const getServerSideProps: GetServerSideProps = async context => {
+    const curDate = new Date().toISOString();
+
+    const { topicContentTypePaths, topicPaths } =
+        await getTopicPagePathMappings();
+    const allContent = await getAllContentItems();
+
+    const staticPages = fs
+        .readdirSync('src/pages', { withFileTypes: true })
+        .filter(
+            dirent =>
+                dirent.isFile() &&
+                !(dirent.name.startsWith('_') || dirent.name.startsWith('[')) &&
+                !dirent.name.includes('index')
+        )
+        .map(dirent => ({
+            loc: `${SITE_URL}/${path.parse(dirent.name).name}`,
+            lastmod: curDate,
+            priority: 1.0,
+        }));
+
+    const topicPages = [
+        ...Object.keys(topicContentTypePaths),
+        ...Object.keys(topicPaths),
+    ].map(path => ({
+        loc: `${SITE_URL}/${path}`,
+        lastmod: curDate,
+        priority: 0.7,
+    }));
+
+    const contentPages = allContent.map(({ slug, contentDate }) => ({
+        loc: `${SITE_URL}/${slug}`,
+        lastmod: contentDate || curDate,
+        priority: 0.5,
+    }));
+
+    return getServerSideSitemap(context, [
+        ...staticPages,
+        ...topicPages,
+        ...contentPages,
+    ]);
+};
+
+export default function SitemapDynamic() {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6268,7 +6268,7 @@ next-seo@5.4.0:
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/next-seo/-/next-seo-5.4.0.tgz#37a7784b30b3f70cec3fa0d77f9dde5990822d24"
   integrity sha1-N6d4SzCz9wzsP6DXf53eWZCCLSQ=
 
-next-sitemap@^3.1.21:
+next-sitemap@3.1.21:
   version "3.1.21"
   resolved "https://registry.npmjs.org/next-sitemap/-/next-sitemap-3.1.21.tgz#aa543acd59f15f7c1f11d5855a84adb9a4bddeb6"
   integrity sha512-8upGCtI91FvjNBpeKDZzrzRBlY4BH6qjG7dMe89sdBzJ9B++PVLTzRPlpLHJYOEPukBROsxi2zVuAvePBtsrdw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,6 +1118,11 @@
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha1-daLotRy3WKdVPWgEpZMteqznXDk=
 
+"@corex/deepmerge@^4.0.29":
+  version "4.0.29"
+  resolved "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.29.tgz#af9debf07d7f6b0d2a9d04a266abf2c1418ed2f6"
+  integrity sha512-q/yVUnqckA8Do+EvAfpy7RLdumnBy9ZsducMUtZTvpdbJC7azEf1hGtnYYxm0QfphYxjwggv6XtH64prvS1W+A==
+
 "@emotion/babel-plugin@11.7.2":
   version "11.7.2"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz#fec75f38a6ab5b304b0601c74e2a5e77c95e5fa0"
@@ -6262,6 +6267,14 @@ next-seo@5.4.0:
   version "5.4.0"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/next-seo/-/next-seo-5.4.0.tgz#37a7784b30b3f70cec3fa0d77f9dde5990822d24"
   integrity sha1-N6d4SzCz9wzsP6DXf53eWZCCLSQ=
+
+next-sitemap@^3.1.21:
+  version "3.1.21"
+  resolved "https://registry.npmjs.org/next-sitemap/-/next-sitemap-3.1.21.tgz#aa543acd59f15f7c1f11d5855a84adb9a4bddeb6"
+  integrity sha512-8upGCtI91FvjNBpeKDZzrzRBlY4BH6qjG7dMe89sdBzJ9B++PVLTzRPlpLHJYOEPukBROsxi2zVuAvePBtsrdw==
+  dependencies:
+    "@corex/deepmerge" "^4.0.29"
+    minimist "^1.2.6"
 
 next@12.1.0:
   version "12.1.0"


### PR DESCRIPTION
[[DEVHUB-1125] NextJS App - Add sitemap](https://jira.mongodb.org/browse/DEVHUB-1125)

Add a sitemap to the site which will reside at [https://mongodb.com/developer/sitemap/sitemap-index.xml](https://mongodb.com/developer/sitemap/sitemap-index.xml) as per the sitemap entry in MongoDB's [main sitemap index file.](https://www.mongodb.com/sitemap.xml)

`next-sitemap` has the ability to generate static sitemaps via a config file, but I didn't use that because of the need for dynamic routes. Their documentation states that in order to have a static and dynamic sitemap in the same app, they must live in separate sitemap files and be referenced by `robots.txt` ([which isn't controlled by this app](https://www.mongodb.com/robots.txt)) and/or referenced by an index sitemap (which also isn't possible, because [index sitemaps shouldn't be nested](https://support.google.com/webmasters/answer/7451001#errors&zippy=%2Cerror-list)).  Because of this, the only solution I found is to manually generate all of the paths dynamically, using `fs` and some of the service functions.

I added priority values to match what seems like the hierarchy of the pages. Main sections of the site, being the most important, I gave priority `1`, specific topics being less important were given `0.7` (`next-sitemap`'s default value), and individual content pages were given `0.5` (the default value in the spec). I can recalibrate these if needed, or remove them altogether as the field is optional.

[Here's a sample of what is generated](https://pastebin.com/raw/xE9ZKi2K). 
