### PR TITLE
[FIX] Add DRONE_TOKEN to the server for preview webhook

### DIFF
--- a/environments/prod.yaml
+++ b/environments/prod.yaml
@@ -10,7 +10,7 @@ env:
 
 envSecrets:
   DEVHUB_URL: devcenter-secrets
-  DRONE_TOKEN: devcenter-secrets
+  DRONE_TOKEN: devcenter-secrets # Only production needs to have this (it's for the preview webhook).
   NEXTAUTH_SECRET: devcenter-secrets
   NPM_EMAIL: devcenter-secrets
   NPM_AUTH: devcenter-secrets

--- a/environments/prod.yaml
+++ b/environments/prod.yaml
@@ -10,6 +10,7 @@ env:
 
 envSecrets:
   DEVHUB_URL: devcenter-secrets
+  DRONE_TOKEN: devcenter-secrets
   NEXTAUTH_SECRET: devcenter-secrets
   NPM_EMAIL: devcenter-secrets
   NPM_AUTH: devcenter-secrets


### PR DESCRIPTION
## Description:

Requests to drone in the webhook were unauthorized because DRONE_TOKEN was undefined at runtime. Only adding to production since staging/preview should not trigger drone events.

## Related Issue(s) or Dependencies (if applicable):

Please link to the issue(s) or dependencies here

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas

