### PR TITLE
Tweak service down alert

### DIFF
--- a/environments/prod.yaml
+++ b/environments/prod.yaml
@@ -70,7 +70,7 @@ metrics:
 prometheusRules:
   - alert: ServiceDown
     expr: sum(up{namespace="devrel", job=~"devcenter-frontend-web-app"}) == 0
-    for: 0m
+    for: 2m
     labels:
       email_to: devhubplatform@mongodb.com
       severity: critical

--- a/environments/staging.yaml
+++ b/environments/staging.yaml
@@ -73,7 +73,7 @@ metrics:
 prometheusRules:
   - alert: ServiceDown
     expr: sum(up{namespace="devrel", job=~"devcenter-frontend-web-app"}) == 0
-    for: 0m
+    for: 2m
     labels:
       email_to: devhubplatform@mongodb.com
       severity: critical


### PR DESCRIPTION
## Jira Ticket:

NONE

## Description:

The alarm gets triggered occasionally during rolling deployments started by the rebuild cron. Let's increase this to 2m instead of 0m to prevent any false alarms.

## Related Issue(s) or Dependencies (if applicable):

Please link to the issue(s) or dependencies here

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added tests that prove my fix is effective or that my feature works (N/A)

