### PR TITLE
[DEVHUB-1501] Adjust cache settings, force revalidation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -65,7 +65,7 @@ steps:
 
 trigger:
   branch:
-    - main
+    - DEVHUB-1501-cache-settings
   event:
     - push
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -65,7 +65,7 @@ steps:
 
 trigger:
   branch:
-    - DEVHUB-1501-cache-settings
+    - main
   event:
     - push
 

--- a/next.config.js
+++ b/next.config.js
@@ -34,7 +34,7 @@ const configVals = {
                 headers: [
                     {
                         key: 'Cache-Control',
-                        value: 'public, must-revalidate, proxy-revalidate, max-age=0',
+                        value: 'public, must-revalidate, proxy-revalidate, max-age=300',
                     },
                     {
                         key: 'Strict-Transport-Security',

--- a/next.config.js
+++ b/next.config.js
@@ -34,7 +34,7 @@ const configVals = {
                 headers: [
                     {
                         key: 'Cache-Control',
-                        value: 'max-age=3600',
+                        value: 'public, must-revalidate, proxy-revalidate, max-age=0',
                     },
                     {
                         key: 'Strict-Transport-Security',
@@ -53,6 +53,15 @@ const configVals = {
                     {
                         key: 'Cache-Control',
                         value: 'no-store, max-age=0',
+                    },
+                ],
+            },
+            {
+                source: '/_next/:path',
+                headers: [
+                    {
+                        key: 'Cache-Control',
+                        value: 'public, max-age=300, immutable',
                     },
                 ],
             },


### PR DESCRIPTION
## Jira Ticket:

DEVHUB-1501

## Description:

Upon deployments, new JS files are generated by Next.js which are by default `immutable` but currently Cloudfront caches HTML/document content for one hour. If code changes and updates are added that effect behavior, this will force the browser cache and/or Cloudfront to revalidate the page by adding `must-revalidate` and `proxy-revalidate` directives. 

In addition, decrease the amount of time the page and JS files are cached for so that they remain fresh.


## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Recordit](https://recordit.co/) app or [Quicktime](https://apple.co/2J1EWUD) screen recorder
