### PR TITLE
[DEVHUB-1508]: MongoDB logo in top left doesn't link back to homepage

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -10,9 +10,9 @@ import { OverlayContext } from '../contexts/overlay';
 import { layers } from '../styled/layout';
 
 const navStyles = {
-    'nav > div > div': {
+    'nav > div > div > ul': {
         zIndex: `${layers.desktopConsistentNavDropdown}!important`,
-    }, // Need this so it can display over our secondary nav
+    }, // Needed so <ul /> list options from consistent nav displays over our secondary nav
     'div[role=menu-wrapper]': {
         zIndex: `${layers.mobileNavMenu}!important`,
     },


### PR DESCRIPTION
## Jira Ticket:

Link to jira ticket [[DEVHUB-1508](https://jira.mongodb.org/browse/DEVHUB-1508)]

## Description:

Target `<ul />` in nav for z-index rule instead of parent `<div />` so list options display over secondary nav

## Related Issue(s) or Dependencies (if applicable):

N/A

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Recordit](https://recordit.co/) app or [Quicktime](https://apple.co/2J1EWUD) screen recorder
