### PR TITLE
[DEVHUB-1103]: Links under videos are not hyperlined

### DIFF
--- a/src/page-templates/main-content-page/content-page-template.tsx
+++ b/src/page-templates/main-content-page/content-page-template.tsx
@@ -381,6 +381,14 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                     sx={{
                         marginBottom: ['inc20', null, null, 'inc40'],
                         whiteSpace: 'pre-wrap',
+                        a: {
+                            color: 'blue60',
+                            '&:hover': {
+                                borderBottomWidth: 2,
+                                borderBottomStyle: 'solid',
+                                borderBottomColor: 'blue80',
+                            },
+                        },
                     }}
                 >
                     {parse(parseUndefinedValue(description))}


### PR DESCRIPTION
## Jira Ticket:

Link to jira ticket [[DEVHUB-1103](https://jira.mongodb.org/browse/DEVHUB-1103)]

## Description:

Video type content was missing hyperlink styling

## Related Issue(s) or Dependencies (if applicable):

Please link to the issue(s) or dependencies here

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
Before:
![Screen Shot 2022-09-23 at 3 44 25 PM](https://user-images.githubusercontent.com/20843509/192046415-62f92996-2d67-4ad7-8123-a4a3a88ccd9a.png)

After:
<img width="822" alt="Screen Shot 2022-09-23 at 3 44 32 PM" src="https://user-images.githubusercontent.com/20843509/192046439-35e0c85f-a821-4bf2-9cda-d91c01cc3610.png">
<img width="784" alt="Screen Shot 2022-09-23 at 3 44 39 PM" src="https://user-images.githubusercontent.com/20843509/192046461-a7fd9666-5eec-42c3-b5b0-68c3baa8a649.png">



