### PR TITLE
[DEVHUB-1265] Hide documentation link if there is no specific documentation for the topic

### DIFF
--- a/src/service/get-all-meta-info.ts
+++ b/src/service/get-all-meta-info.ts
@@ -100,9 +100,7 @@ const getMetaInfo = (m: MetaInfoResponse): MetaInfo => {
         slug: m.slug,
         ctas: getCTAs(m.primary_cta, m.secondary_cta),
         topics: [],
-        documentationLink: m.documentation_link
-            ? m.documentation_link
-            : DOCS_UNIVERSAL_LINK,
+        documentationLink: m.documentation_link || '',
     };
 };
 


### PR DESCRIPTION
## Jira Ticket:

[[DEVHUB-1265] Hide documentation link if there is no specific documentation for the topic](https://jira.mongodb.org/browse/DEVHUB-1265)

## Description:

Topics or content that do not have a specific link to related documentation default to docs.mongodb.com currently. This change is to remove the documentation link altogether when there is no specific related documentation.

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
Topic without a documentation link
<img width="717" alt="Screen Shot 2022-10-05 at 3 50 51 PM" src="https://user-images.githubusercontent.com/110849018/194150030-d619dd0c-468a-4bc8-b68d-23d1b7fec99c.png">

Topic with a documentation link
<img width="815" alt="Screen Shot 2022-10-05 at 3 51 06 PM" src="https://user-images.githubusercontent.com/110849018/194150074-1de4af18-8d13-49ec-996e-5e69d4d6a330.png">
