### PR TITLE
Fix sort by styling on search component

### DIFF
--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -204,13 +204,14 @@ const Search: React.FunctionComponent<SearchProps> = ({
                 )}
             </div>
             <Grid
-                columns={[1, null, 8, 3]}
+                columns={[1, null, 3]}
                 sx={{ ...searchBoxSortBarWrapperStyles }}
             >
                 <div
                     sx={{
                         ...searchBoxStyles,
                         ...extraSearchBoxStyles,
+                        gridColumn: ['span 1', null, 'span 2'],
                     }}
                 >
                     <TextInput
@@ -225,7 +226,11 @@ const Search: React.FunctionComponent<SearchProps> = ({
                     />
                 </div>
                 <Select
-                    sx={sortBoxStyles}
+                    sx={{
+                        ...sortBoxStyles,
+                        display: 'block',
+                        gridColumn: 'span 1',
+                    }}
                     label="Sort by"
                     name="sort-by-dropdown"
                     options={Object.keys(sortByOptions)}


### PR DESCRIPTION
Follow up to https://github.com/mongodb/devcenter/pull/332 which introduced a styling issue on pages with sorting but not filtering. This PR should fix those issues.