### PR TITLE
[DEVHUB-1557] fix user menu positioning on mobile/tablet

### DIFF
--- a/src/components/seconardynavnew/mobile-styles.ts
+++ b/src/components/seconardynavnew/mobile-styles.ts
@@ -124,6 +124,7 @@ export const chevronStylesForMainLink: ThemeUIStyleObject = {
 
 export const userMenuStyles: ThemeUIStyleObject = {
     minWidth: 'inc60',
+    marginLeft: 'auto',
 };
 
 export const DropDownStyles = {


### PR DESCRIPTION
## Jira Ticket:
[DEVHUB-1557](https://jira.mongodb.org/browse/DEVHUB-1557)

## Description:

User menu was being center aligned on mobile and tablet viewports. Adding a auto margin to push it over to the right.

