### PR TITLE
Fix Canonical URL Logic

### DIFF
--- a/src/hooks/search/meta.ts
+++ b/src/hooks/search/meta.ts
@@ -56,7 +56,9 @@ export const useSearchMeta = (
             setCanonicalUrl(
                 getCanonicalUrlWithParams(
                     absoluteBasePath,
-                    `${pathWithoutParams}?page=${pageNumber}`,
+                    pageNumber <= 1
+                        ? asPath
+                        : `${pathWithoutParams}?page=${pageNumber}`,
                     {
                         page: pageNumber.toString(),
                     }


### PR DESCRIPTION
## Jira Ticket:

N/A 

## Description:

Found a small bug while poking around staging, when a search page reset its page to 1, the canonical url would reset to `/developer/<slug>/?page=1` instead of just `/developer/<slug>`. This should fix that

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added tests that prove my fix is effective or that my feature works