### PR TITLE
Pin ubuntu version to 20.04 for playwright tests in GitHub actions

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -37,7 +37,7 @@ jobs:
             - name: Lint
               run: yarn lint
     playwright-tests:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             - name: Checkout target branch
               uses: actions/checkout@v2


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/6399
GitHub is migrating their `ubuntu-latest` image from `20.04` to `22.04` which seems to be breaking playwright. Pinning it to the version that was being used previously for now which should fix the issue.