### PR TITLE
Change View Code icon to Github Octocat

### DIFF
--- a/src/page-templates/content-page/content-page-template.tsx
+++ b/src/page-templates/content-page/content-page-template.tsx
@@ -187,7 +187,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                     href={githubUrl}
                     target="_blank"
                     variant="secondary"
-                    iconName={ESystemIconNames.EXTERNAL}
+                    iconName={ESystemIconNames.SOCIAL_GITHUB}
                     sx={{ width: 'auto' }}
                 >
                     View Code


### PR DESCRIPTION
## Jira Ticket:

[[DEVHUB-1499] Utilize GitHub Octocat](https://jira.mongodb.org/browse/DEVHUB-1499)

## Description:
Changed the previous external link icon to a GitHub icon for code example pages

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
Before:
<img width="1308" alt="Screen Shot 2022-11-30 at 1 02 19 PM" src="https://user-images.githubusercontent.com/110849018/204873856-9440e677-e12b-431d-97f7-3be08c71099e.png">

After:
<img width="1400" alt="Screen Shot 2022-11-30 at 1 02 04 PM" src="https://user-images.githubusercontent.com/110849018/204873814-78de27e4-ede0-444a-b29d-a5da0abb0b91.png">
