### PR TITLE
Run Github actions on main push for Percy

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,5 +1,7 @@
 name: Pull Request Checks
 on:
+    push:
+        branches: [main]
     pull_request:
         branches: [main]
 env:


### PR DESCRIPTION
Github actions aren't being run on the main branch currently. Percy needs to have a [base build](https://docs.percy.io/docs/baseline-picking-logic#setting-the-projects-default-base-branch) in order to compare PR builds against, the idea being that any code pushed to the base branch is approved visually. By running these checks on the main branch, Percy will consider the build a base build and be able to compare subsequent builds against it.