### PR TITLE
[DEVHUB-1531]: Adding Events Widget in scope of Industry Event Details Page

### DIFF
--- a/src/components/event-widget/event-widget.test.tsx
+++ b/src/components/event-widget/event-widget.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import EventWidget from '.';
+
+describe('[Component]: Event Widget', () => {
+    const location = '1633 Broadway 38th floor, New York, NY 10019';
+    const virtualLink = 'www.loremipsum.com/my-event';
+    const virtualLinkText = 'Super Chill Virtual Event';
+
+    it('renders', () => {
+        const { container } = render(
+            <EventWidget
+                startTime={new Date('2022-11-30T17:00:00.000Z')}
+                endTime={new Date('2022-12-01T17:00:00.000Z')}
+                location={location}
+                virtualLink={virtualLink}
+                virtualLinkText={virtualLinkText}
+            />
+        );
+
+        // formats provided dates
+        expect(
+            screen.getByText('11/30/2022, 12:00:00 PM - 12/1/2022, 12:00:00 PM')
+        ).toBeInTheDocument();
+
+        // sets location
+        expect(screen.getByText(location)).toBeInTheDocument();
+
+        // sets link with proper attributes
+        const link = container.getElementsByTagName('a')[0];
+        expect(link).toHaveAttribute('href', virtualLink);
+        expect(screen.getByText(virtualLinkText)).toBeInTheDocument();
+    });
+
+    it('sets default props', () => {
+        render(
+            <EventWidget
+                startTime={new Date('2022-11-30T17:00:00.000Z')}
+                endTime={new Date('2022-12-01T17:00:00.000Z')}
+                virtualLink={virtualLink}
+            />
+        );
+
+        expect(screen.getByText('Virtual Link')).toBeInTheDocument();
+    });
+});

--- a/src/components/event-widget/event-widget.test.tsx
+++ b/src/components/event-widget/event-widget.test.tsx
@@ -19,9 +19,15 @@ describe('[Component]: Event Widget', () => {
             />
         );
 
-        // formats provided dates
+        /*
+            Only test for date formatting because of .toLocateString() usage
+            Exact match would cause wacky behavior of times when running tests locally vs. during build
+        */
         expect(
-            screen.getByText('11/30/2022, 12:00:00 PM - 12/1/2022, 12:00:00 PM')
+            screen.getByText('11/30/2022', { exact: false })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('12/1/2022', { exact: false })
         ).toBeInTheDocument();
 
         // sets location

--- a/src/components/event-widget/event-widget.tsx
+++ b/src/components/event-widget/event-widget.tsx
@@ -1,0 +1,65 @@
+import {
+    Button,
+    ESystemIconNames,
+    Link,
+    SystemIcon,
+    TypographyScale,
+} from '@mdb/flora';
+
+import styles from './styles';
+
+interface EventWidgetProps {
+    startTime: Date;
+    endTime: Date;
+    location?: string;
+    virtualLink?: string;
+    virtualLinkText?: string;
+}
+
+export default function EventWidget({
+    startTime,
+    endTime,
+    location = '',
+    virtualLink = '',
+    virtualLinkText = 'Virtual Link',
+}: EventWidgetProps) {
+    return (
+        <>
+            <div sx={styles.widget}>
+                <div sx={styles.header}>
+                    {/* TODO: placeholder icon should be updated when https://jira.mongodb.org/browse/WEBSITE-13740 is ready from Flora */}
+                    <SystemIcon name={ESystemIconNames.APP_WINDOW} />
+                    <TypographyScale sx={styles.title} variant="heading6">
+                        When
+                    </TypographyScale>
+                </div>
+                <TypographyScale
+                    variant="body3"
+                    sx={styles.content}
+                >{`${startTime.toLocaleString()} - ${endTime.toLocaleString()}`}</TypographyScale>
+            </div>
+            {(location || virtualLink) && (
+                <div sx={styles.widget}>
+                    <div sx={styles.header}>
+                        {/* TODO: placeholder icon should be updated when https://jira.mongodb.org/browse/WEBSITE-13740 is ready from Flora */}
+                        <SystemIcon name={ESystemIconNames.HEART} />
+                        <TypographyScale sx={styles.title} variant="heading6">
+                            Location
+                        </TypographyScale>
+                    </div>
+                    {location && (
+                        <TypographyScale variant="body3" sx={styles.content}>
+                            {location}
+                        </TypographyScale>
+                    )}
+                    {virtualLink && (
+                        <Link href={virtualLink} sx={styles.content}>
+                            {virtualLinkText}
+                        </Link>
+                    )}
+                </div>
+            )}
+            <Button sx={styles.button}>Register Now</Button>
+        </>
+    );
+}

--- a/src/components/event-widget/index.tsx
+++ b/src/components/event-widget/index.tsx
@@ -1,0 +1,3 @@
+import EventWidget from './event-widget';
+
+export default EventWidget;

--- a/src/components/event-widget/styles.ts
+++ b/src/components/event-widget/styles.ts
@@ -1,0 +1,30 @@
+const header = {
+    display: 'flex',
+    alignItems: 'center',
+};
+
+const widget = {
+    marginBottom: 'inc50',
+};
+
+const title = {
+    marginLeft: 'inc20',
+};
+
+const content = {
+    marginTop: 'inc20',
+};
+
+const button = {
+    marginTop: 'inc30',
+};
+
+const styles = {
+    title,
+    header,
+    widget,
+    button,
+    content,
+};
+
+export default styles;


### PR DESCRIPTION
## Jira Ticket:

Link to jira ticket [[DEVHUB-1531](https://jira.mongodb.org/browse/DEVHUB-1531)]

## Description:

Adding `<EventWidget />` component that will be used in the Industry Events Detail Page. Just adding this component in isolation for now as we work through getting the UI ready for integration once the Event API's are ready.

## Checklist: (Check off where applicable)?
-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
Using placeholder icons for now, Flora team needs to add the new ones. it's been commented in the code
<img width="321" alt="Screen Shot 2022-12-06 at 3 52 11 PM" src="https://user-images.githubusercontent.com/20843509/206020455-5351313e-9ee2-4cac-91d2-873e5b9b9219.png">
