### PR TITLE
Github Actions Push Jest Fix

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,7 +1,7 @@
 name: Pull Request Checks
 on:
     push:
-        branches: [main, mm/test-jest-fix]
+        branches: [main]
     pull_request:
         branches: [main]
 env:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -102,6 +102,10 @@ jobs:
               with:
                   skip-step: install
               uses: ArtiomTr/jest-coverage-report-action@v2
+              if: github.event_name == 'pull_request'
+            - name: Run Jest without coverage report
+              run: npx jest
+              if: github.event_name != 'pull_request'
     lighthouse:
         name: Lighthouse
         runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,7 +1,7 @@
 name: Pull Request Checks
 on:
     push:
-        branches: [main]
+        branches: [main, mm/test-jest-fix]
     pull_request:
         branches: [main]
 env:

--- a/src/components/search/results.test.tsx
+++ b/src/components/search/results.test.tsx
@@ -55,7 +55,7 @@ describe('Search Results', () => {
     test('renders loading spinner', () => {
         render(<Results results={undefined} isValidating />);
 
-        const spinner = screen.getByAltText('Loading...');
+        const spinner = screen.getByAltText('Loadingabc...');
         expect(spinner).toBeInTheDocument();
     });
     test('renders error message', () => {

--- a/src/components/search/results.test.tsx
+++ b/src/components/search/results.test.tsx
@@ -55,7 +55,7 @@ describe('Search Results', () => {
     test('renders loading spinner', () => {
         render(<Results results={undefined} isValidating />);
 
-        const spinner = screen.getByAltText('Loadingabc...');
+        const spinner = screen.getByAltText('Loading...');
         expect(spinner).toBeInTheDocument();
     });
     test('renders error message', () => {


### PR DESCRIPTION
Following https://github.com/mongodb/devcenter/pull/386, Jest tests were failing when the actions were running on the `main` branch, because the Jest PR coverage report was trying to run on a non-PR. Didn't really affect anything, but it's nice to not get a "Run failed" email every time a PR is merged. 

One slightly useful side effect is that the actions should run to completion on all branches now, so if one were to add their branch name to the `branches` array for testing purposes, the Jest action should work now whereas it would not have previously.