### PR TITLE
[CHORE]: Bump decode-uri-component from 0.2.0 to 0.2.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3976,7 +3976,7 @@ decimal.js@^10.2.1:
   integrity sha1-2MOkRKnGd0umDKatcmHDqU/V54M=
 
 decode-uri-component@^0.2.0:
-  version "0.2.0"
+  version "0.2.2"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3977,8 +3977,8 @@ decimal.js@^10.2.1:
 
 decode-uri-component@^0.2.0:
   version "0.2.2"
-  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+  resolved "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 decompress-response@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Alleviates https://github.com/mongodb/devcenter/pull/387