### PR TITLE
[DEVHUB-1609] Refactor Filtering Utils to be Generic

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,5 +1,6 @@
-import path from 'path';
-import fs from 'fs';
+/* eslint-disable */
+const path = require('path');
+const fs = require('fs');
 
 const disallowedPages = ['index.tsx', 'test-api.tsx'];
 

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,5 +1,5 @@
-const path = require('path');
-const fs = require('fs');
+import path from 'path';
+import fs from 'fs';
 
 const disallowedPages = ['index.tsx', 'test-api.tsx'];
 
@@ -44,6 +44,7 @@ module.exports = {
                 'inspector-issues': 'warn',
                 'offscreen-images': 'warn',
                 'non-composited-animations': 'warn',
+                'no-document-write': 'warn',
                 'unsized-images': 'warn',
                 'unused-css-rules': 'warn',
                 'unused-javascript': 'warn',

--- a/src/components/search-filters/desktop/filters.test.tsx
+++ b/src/components/search-filters/desktop/filters.test.tsx
@@ -32,7 +32,7 @@ test('renders desktop filters', () => {
             onFilter={() => counter++}
             filters={[]}
             filterItems={[
-                { key: 'ProgrammingLanguage', value: languageFilterItems },
+                { key: 'Language', value: languageFilterItems },
                 { key: 'Technology', value: technologyFilterItems },
             ]}
         />

--- a/src/components/search-filters/desktop/filters.tsx
+++ b/src/components/search-filters/desktop/filters.tsx
@@ -2,7 +2,6 @@ import { useCallback, memo } from 'react';
 import { FiltersProps } from '../types';
 
 import { FilterGroup, FilterItem } from '@mdb/devcenter-components';
-import { CONTENT_TYPE_NAME_MAP } from '../../../data/constants';
 
 const DesktopFilters: React.FunctionComponent<FiltersProps> = memo(
     ({ className, onFilter, filters, filterItems }) => {
@@ -40,7 +39,7 @@ const DesktopFilters: React.FunctionComponent<FiltersProps> = memo(
             <div className={className}>
                 {filterItems.map(({ key, value }) => (
                     <FilterGroup
-                        title={CONTENT_TYPE_NAME_MAP[key]}
+                        title={key}
                         allFilters={value}
                         activeFilters={filters}
                         onToggle={onToggle}

--- a/src/components/search-filters/mobile/filters.test.tsx
+++ b/src/components/search-filters/mobile/filters.test.tsx
@@ -33,7 +33,7 @@ test('renders mobile filters', () => {
             onFilter={() => filterCounter++}
             filters={[]}
             filterItems={[
-                { key: 'ProgrammingLanguage', value: languageFilterItems },
+                { key: 'Language', value: languageFilterItems },
                 { key: 'Technology', value: technologyFilterItems },
             ]}
             closeModal={() => closeCounter++}

--- a/src/components/search-filters/mobile/filters.tsx
+++ b/src/components/search-filters/mobile/filters.tsx
@@ -13,7 +13,6 @@ import { FiltersProps } from '../types';
 
 import RadioFilterGroup from '../radio-filter-group';
 import { buttonSection, filtersModal, titleSection } from './styles';
-import { CONTENT_TYPE_NAME_MAP } from '../../../data/constants';
 import { defaultSortByType } from '../../search/types';
 
 interface MobileFiltersProps extends FiltersProps {
@@ -92,7 +91,7 @@ const MobileFilters: React.FunctionComponent<MobileFiltersProps> = memo(
                     {filterItems.map(({ key, value }) => (
                         <>
                             <FilterGroup
-                                title={CONTENT_TYPE_NAME_MAP[key]}
+                                title={key}
                                 allFilters={value}
                                 activeFilters={tempFilters}
                                 onToggle={onToggle}

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,3 +1,4 @@
+import { PillCategory } from '../types/pill-category';
 import { TagType } from '../types/tag-type';
 
 export const L1L2_TOPIC_PAGE_TYPES: TagType[] = [
@@ -8,14 +9,86 @@ export const L1L2_TOPIC_PAGE_TYPES: TagType[] = [
     'ExpertiseLevel',
 ];
 
-export const CONTENT_TYPE_NAME_MAP: { [type: string]: string } = {
-    ProgrammingLanguage: 'Language',
-    Technology: 'Technology',
-    ContentType: 'Content Type',
-    L1Product: 'Products',
-    ExpertiseLevel: 'Expertise Level',
-    AuthorType: 'Contributed By',
-    ExampleType: 'Example Type',
-};
+interface FilterItemModel {
+    displayName: string;
+    type: string;
+    forContentType?: PillCategory | '';
+    subFilters?: TagType[];
+    query?: string;
+}
 
 export const DEBOUNCE_WAIT = 400; // in milliseconds
+
+export const FILTER_ITEM_MODEL: FilterItemModel[] = [
+    {
+        displayName: 'Language',
+        type: 'ProgrammingLanguage',
+        query: 'language',
+    },
+    {
+        displayName: 'Technology',
+        type: 'Technology',
+        query: 'technology',
+    },
+    {
+        displayName: 'Content Type',
+        type: 'ContentType',
+        forContentType: '',
+        subFilters: ['CodeLevel'],
+        query: 'contentType',
+    },
+    {
+        displayName: 'Products',
+        type: 'L1Product',
+        subFilters: ['L2Product'],
+        query: 'product',
+    },
+    {
+        displayName: 'Expertise Level',
+        type: 'ExpertiseLevel',
+        query: 'expertiseLevel',
+    },
+    {
+        displayName: 'Contributed By',
+        type: 'AuthorType',
+        query: 'contributedBy',
+    },
+    {
+        displayName: 'Example Type',
+        type: 'CodeLevel',
+        forContentType: 'Code Example',
+        query: 'exampleType',
+    },
+];
+
+/*
+    Doing some preprocessing on the filter item model below to 
+    make some of the filter operations more efficient
+*/
+
+// Returns an object mapping sub-filters to their parent types e.g. { L2Product: 'L1Product', ... }
+export const FILTER_ITEM_SUBFILTER_MAP = FILTER_ITEM_MODEL.reduce(
+    (acc, model) =>
+        model.subFilters
+            ? {
+                  ...acc,
+                  ...model.subFilters.reduce(
+                      (a, v) => ({ ...a, [v]: model.type }),
+                      {}
+                  ),
+              }
+            : acc,
+    {}
+) as { [subFilter in TagType]: TagType };
+
+// Returns an object mapping types to their associated FilterItemModel
+export const FILTER_ITEM_TYPE_MAP = FILTER_ITEM_MODEL.reduce(
+    (acc, model) => ({ ...acc, [model.type]: model }),
+    {}
+) as { [type: string]: FilterItemModel };
+
+// Returns an object mapping query strings to their associated FilterItemModel
+export const FILTER_ITEM_QUERY_MAP = FILTER_ITEM_MODEL.reduce(
+    (acc, model) => (model.query ? { ...acc, [model.query]: model } : acc),
+    {}
+) as { [type: string]: FilterItemModel };

--- a/src/hooks/search/index.ts
+++ b/src/hooks/search/index.ts
@@ -4,6 +4,7 @@ import useSWR from 'swr';
 import { FilterItem } from '@mdb/devcenter-components';
 import {
     fetcher,
+    getFiltersFromQueryStr,
     itemInFilters,
     searchItemToContentItem,
     updateUrl,
@@ -61,7 +62,7 @@ const useSearch = (
             setSearchString(event.target.value);
 
             if (shouldUseQueryParams) {
-                updateUrl(router, filters, event.target.value);
+                updateUrl(router.pathname, filters, event.target.value);
             }
         },
         [filters, router, shouldUseQueryParams, updatePageMeta]
@@ -73,7 +74,7 @@ const useSearch = (
             setFilters(filters);
 
             if (shouldUseQueryParams) {
-                updateUrl(router, filters, searchString);
+                updateUrl(router.pathname, filters, searchString);
             }
         },
         [router, searchString, shouldUseQueryParams, updatePageMeta]
@@ -86,7 +87,7 @@ const useSearch = (
 
             if (shouldUseQueryParams) {
                 updateUrl(
-                    router,
+                    router.pathname,
                     filters,
                     searchString,
                     sortByValue as SortByType
@@ -107,127 +108,16 @@ const useSearch = (
         };
     }, [debouncedOnSearch]);
 
-    const getFiltersFromQueryStr = useCallback(() => {
-        const l1Items = filterItems?.find(
-            item => item.key === 'L1Product'
-        )?.value;
-        const contentTypeItems = filterItems?.find(
-            item => item.key === 'ContentType'
-        )?.value;
-        const languageItems = filterItems?.find(
-            item => item.key === 'ProgrammingLanguage'
-        )?.value;
-        const technologyItems = filterItems?.find(
-            item => item.key === 'Technology'
-        )?.value;
-        const contributedByItems = filterItems?.find(
-            item => item.key === 'AuthorType'
-        )?.value;
-        const expertiseLevelItems = filterItems?.find(
-            item => item.key === 'ExpertiseLevel'
-        )?.value;
-
-        const {
-            product,
-            language,
-            technology,
-            contributedBy,
-            contentType,
-            expertiseLevel,
-        } = router.query;
-
-        const buildFilters = (
-            filterType: string | string[],
-            filterTypeItems: FilterItem[]
-        ) => {
-            const items =
-                typeof filterType === 'object' ? filterType : [filterType];
-            const filtersList: FilterItem[] = [];
-
-            // Gotta look for L1s and L2s that match.
-            items.forEach(item => {
-                const filterProduct = filterTypeItems.find(
-                    l1 =>
-                        l1.name === item ||
-                        l1.subFilters?.find(l2 => l2.name === item)
-                );
-                if (filterProduct) {
-                    if (filterProduct.name !== item) {
-                        // This means it's an L2 match.
-                        filtersList.push(
-                            filterProduct.subFilters?.find(
-                                l2 => l2.name === item
-                            ) as FilterItem
-                        );
-                    } else {
-                        filtersList.push(filterProduct);
-                    }
-                }
-            });
-            return filtersList;
-        };
-
-        let allNewFilters: FilterItem[] = [];
-        if (product && l1Items) {
-            const productFilters: FilterItem[] = buildFilters(product, l1Items);
-            allNewFilters = allNewFilters.concat(productFilters);
-        }
-        if (contentType && contentTypeItems) {
-            const contentTypeFilters: FilterItem[] = buildFilters(
-                contentType,
-                contentTypeItems
-            );
-            allNewFilters = allNewFilters.concat(contentTypeFilters);
-        }
-        // For the rest, just map it to the corresponding item.
-        if (language && languageItems) {
-            // Technically can either come in as a string of a string[], so convert to a string[]
-            // and loop over by default.
-            const languages =
-                typeof language === 'object' ? language : [language];
-            const languageFilters = languageItems.filter(lang =>
-                languages.includes(lang.name)
-            );
-            allNewFilters = allNewFilters.concat(languageFilters);
-        }
-        if (technology && technologyItems) {
-            const technologies =
-                typeof technology === 'object' ? technology : [technology];
-            const technologyFilters = technologyItems.filter(tech =>
-                technologies.includes(tech.name)
-            );
-            allNewFilters = allNewFilters.concat(technologyFilters);
-        }
-        if (contributedBy && contributedByItems) {
-            const contributedBys =
-                typeof contributedBy === 'object'
-                    ? contributedBy
-                    : [contributedBy];
-            const contributedByFilters = contributedByItems.filter(contrib =>
-                contributedBys.includes(contrib.name)
-            );
-            allNewFilters = allNewFilters.concat(contributedByFilters);
-        }
-        if (expertiseLevel && expertiseLevelItems) {
-            const expertiseLevels =
-                typeof expertiseLevel === 'object'
-                    ? expertiseLevel
-                    : [expertiseLevel];
-            const expertiseLevelFilters = expertiseLevelItems.filter(exp =>
-                expertiseLevels.includes(exp.name)
-            );
-            allNewFilters = allNewFilters.concat(expertiseLevelFilters);
-        }
-        return allNewFilters;
-    }, [filterItems, router.query]);
-
     // Populate the search/filters with query params on page load/param change if we have a router and filters defined.
     useEffect(() => {
         if (router?.isReady) {
             const { s } = router.query;
 
             if (filterItems) {
-                const allNewFilters = getFiltersFromQueryStr();
+                const allNewFilters = getFiltersFromQueryStr(
+                    router.query,
+                    filterItems
+                );
                 setFilters(allNewFilters);
             }
 

--- a/src/hooks/search/utils.test.tsx
+++ b/src/hooks/search/utils.test.tsx
@@ -345,7 +345,7 @@ describe('getFiltersFromQueryString', () => {
         const query = querystring.parse(
             'language=Java&language=Python&language=JavaScript'
         ) as ParsedUrlQuery;
-        console.log(query);
+
         const filters = getFiltersFromQueryStr(query, mockFilterItems);
 
         expect(filters.length).toBe(3);

--- a/src/hooks/search/utils.test.tsx
+++ b/src/hooks/search/utils.test.tsx
@@ -1,10 +1,445 @@
 import '@testing-library/jest-dom';
 
-import { isEmptyArray } from './utils';
+import { Tag } from '../../interfaces/tag';
+
+import {
+    getFilters,
+    getFiltersFromQueryStr,
+    isEmptyArray,
+    updateUrl,
+} from './utils';
+import { MOCK_ARTICLE_TAGS } from '../../mockdata/mock-tags';
+import { SearchItem } from '../../components/search/types';
+import { FilterItem } from '@mdb/devcenter-components';
+import { FILTER_ITEM_MODEL } from '../../data/constants';
+import querystring, { ParsedUrlQuery } from 'querystring';
 
 test('correctly checks if array is empty', () => {
     expect(isEmptyArray([{}, {}])).toBeFalsy();
     expect(isEmptyArray([])).toBeTruthy();
     expect(isEmptyArray(null)).toBeTruthy();
     expect(isEmptyArray(undefined)).toBeTruthy();
+});
+
+const mockImage = {
+    url: 'url',
+    alternativeText: 'alt',
+    city: 'city',
+};
+
+const mockSearchDataFactory = (tags: Tag[]) =>
+    [
+        {
+            type: 'Article',
+            authors: [
+                {
+                    name: 'Author',
+                    image: mockImage,
+                    calculated_slug: '/slug',
+                },
+            ],
+            name: 'Article Name',
+            image: mockImage,
+            description: 'Article Description',
+            slug: '/articles/article',
+            date: '2022-12-20T02:31:39.476Z',
+            tags,
+        },
+    ] as SearchItem[];
+
+describe('getFilters', () => {
+    test('Top level tags on search items show up in outputted filters', async () => {
+        const mockSearchData = mockSearchDataFactory(MOCK_ARTICLE_TAGS);
+        const filterItemValues = (
+            await getFilters('Article', mockSearchData)
+        ).flatMap(item => item.value);
+
+        MOCK_ARTICLE_TAGS.forEach((tag: Tag) => {
+            expect(
+                filterItemValues.some(
+                    (x: FilterItem) =>
+                        x.name === tag.name && x.type === tag.type
+                )
+            ).toBeTruthy();
+        });
+    });
+
+    test('Sub-filters are grouped together with their parent filter properly', async () => {
+        const tags = [
+            // Snippet should be grouped in a subfilter under the content type tag
+            {
+                name: 'Code Example',
+                type: 'ContentType',
+                slug: '/code-examples',
+            },
+            { name: 'Snippet', type: 'CodeLevel', slug: '/code-examples' },
+        ] as Tag[];
+
+        const mockSearchData = mockSearchDataFactory(tags);
+        const filterItems = await getFilters(undefined, mockSearchData);
+        const contentTypeFilterItems = filterItems.find(
+            item => item.key === 'Content Type'
+        )?.value;
+
+        expect(contentTypeFilterItems).toBeDefined();
+        expect(contentTypeFilterItems?.length).toBe(1);
+        expect(contentTypeFilterItems?.[0].subFilters?.length).toBe(1);
+        expect(contentTypeFilterItems?.[0].subFilters?.[0].type).toBe(
+            'CodeLevel'
+        );
+        expect(contentTypeFilterItems?.[0].subFilters?.[0].name).toBe(
+            'Snippet'
+        );
+    });
+
+    test('ContentType-specific filters only show up with that content type', async () => {
+        const tags = [
+            { name: 'Snippet', type: 'CodeLevel', slug: '/code-examples' },
+        ] as Tag[];
+
+        const mockSearchData = mockSearchDataFactory(tags);
+        const filterItemsCodeExampleContentType = await getFilters(
+            'Code Example',
+            mockSearchData
+        );
+        const filterItemsArticleContentType = await getFilters(
+            'Article',
+            mockSearchData
+        );
+
+        expect(filterItemsCodeExampleContentType.length).toBe(1);
+        expect(filterItemsArticleContentType.length).toBe(0);
+    });
+
+    test('All types of filters are displayed when content type is empty (e.g. sitewide search)', async () => {
+        const tags = FILTER_ITEM_MODEL.map(({ type }) => ({
+            type,
+            name: 'Test',
+        })) as Tag[];
+
+        const mockSearchData = mockSearchDataFactory(tags);
+
+        const filterItemValues = (
+            await getFilters(undefined, mockSearchData)
+        ).flatMap(item => item.value);
+
+        FILTER_ITEM_MODEL.forEach(({ type }) => {
+            expect(filterItemValues.some(x => x.type === type)).toBeTruthy();
+        });
+    });
+
+    test('CodeLevel filters are scrubbed out of all content type tags except Code Examples', async () => {
+        const articleContentTypeTags = [
+            { name: 'Article', type: 'ContentType', slug: '/articles' },
+            { name: 'Snippet', type: 'CodeLevel', slug: '/code-examples' },
+        ] as Tag[];
+
+        const codeExampleContentTypeTags = [
+            {
+                name: 'Code Example',
+                type: 'ContentType',
+                slug: '/code-examples',
+            },
+            { name: 'Snippet', type: 'CodeLevel', slug: '/code-examples' },
+        ] as Tag[];
+
+        const articleFilterItems = await getFilters(
+            undefined,
+            mockSearchDataFactory(articleContentTypeTags)
+        );
+        const codeExampleFilterItems = await getFilters(
+            undefined,
+            mockSearchDataFactory(codeExampleContentTypeTags)
+        );
+
+        expect(
+            articleFilterItems?.find(x => x.key === 'Content Type')?.value?.[0]
+                ?.subFilters?.length
+        ).toBe(0);
+        expect(
+            codeExampleFilterItems?.find(x => x.key === 'Content Type')
+                ?.value?.[0]?.subFilters?.length
+        ).toBe(1);
+    });
+
+    test('Sorting filters by count works properly', async () => {
+        const allTags = [
+            {
+                name: 'JavaScript',
+                type: 'ProgrammingLanguage',
+                slug: '/languages/javascript',
+            },
+            {
+                name: 'C#',
+                type: 'ProgrammingLanguage',
+                slug: '/expertise-levels/csharp',
+            },
+            {
+                name: 'Python',
+                type: 'ProgrammingLanguage',
+                slug: '/technologies/python',
+            },
+            {
+                name: 'Kotlin',
+                type: 'ProgrammingLanguage',
+                slug: '/products/kotlin',
+            },
+            {
+                name: 'Java',
+                type: 'ProgrammingLanguage',
+                slug: '/author-types/java',
+            },
+        ] as Tag[];
+
+        // Construct 5 search items, each with one more tag than the last
+        // Output should end up sorted in the order of the allTags array items
+        const searchData = [...new Array(allTags.length)].flatMap((_, i) =>
+            mockSearchDataFactory(allTags.slice(0, i + 1))
+        );
+        const filterValue = (await getFilters(undefined, searchData))?.[0]
+            ?.value;
+
+        expect(filterValue?.[0]?.name).toBe('JavaScript');
+        expect(filterValue?.[1]?.name).toBe('C#');
+        expect(filterValue?.[2]?.name).toBe('Python');
+        expect(filterValue?.[3]?.name).toBe('Kotlin');
+        expect(filterValue?.[4]?.name).toBe('Java');
+    });
+
+    test('Sorting subFilters by count works properly', async () => {
+        const allSubFilterTags = [
+            {
+                name: 'Search',
+                type: 'L2Product',
+                slug: '/products/atlas/search',
+            },
+            {
+                name: 'Data API',
+                type: 'L2Product',
+                slug: '/products/atlas/data-api',
+            },
+            {
+                name: 'Data Lake',
+                type: 'L2Product',
+                slug: '/products/atlas/data-lake',
+            },
+            {
+                name: 'Charts',
+                type: 'L2Product',
+                slug: '/products/atlas/charts',
+            },
+            {
+                name: 'Data Federation',
+                type: 'L2Product',
+                slug: '/products/atlas/data-federation',
+            },
+        ] as Tag[];
+
+        const searchData = [];
+
+        for (let i = 0; i < allSubFilterTags.length; i++) {
+            searchData.push(
+                ...[...new Array(allSubFilterTags.length - i)].flatMap(() =>
+                    mockSearchDataFactory([
+                        {
+                            name: 'Atlas',
+                            type: 'L1Product',
+                            slug: '/products/atlas',
+                        },
+                        allSubFilterTags[i],
+                    ])
+                )
+            );
+        }
+
+        const subFilters = (await getFilters(undefined, searchData))?.[0]
+            ?.value?.[0]?.subFilters;
+
+        expect(subFilters?.[0]?.name).toBe('Search');
+        expect(subFilters?.[1]?.name).toBe('Data API');
+        expect(subFilters?.[2]?.name).toBe('Data Lake');
+        expect(subFilters?.[3]?.name).toBe('Charts');
+        expect(subFilters?.[4]?.name).toBe('Data Federation');
+    });
+});
+
+const mockFilterItems = [
+    {
+        key: 'Language',
+        value: [
+            {
+                name: 'Java',
+                type: 'ProgrammingLanguage',
+                subFilters: [],
+                count: 1,
+            },
+            {
+                name: 'JavaScript',
+                type: 'ProgrammingLanguage',
+                subFilters: [],
+                count: 0,
+            },
+            {
+                name: 'Python',
+                type: 'ProgrammingLanguage',
+                subFilters: [],
+                count: 0,
+            },
+        ],
+    },
+    {
+        key: 'Technology',
+        value: [
+            {
+                name: 'Serverless',
+                type: 'Technology',
+                subFilters: [],
+                count: 1,
+            },
+        ],
+    },
+    {
+        key: 'Products',
+        value: [
+            {
+                name: 'MongoDB',
+                type: 'L1Product',
+                subFilters: [
+                    {
+                        name: 'Schema',
+                        type: 'L2Product',
+                        subFilters: [],
+                        count: 0,
+                    },
+                ],
+            },
+            {
+                name: 'Atlas',
+                type: 'L1Product',
+                subFilters: [
+                    {
+                        name: 'Search',
+                        type: 'L2Product',
+                        subFilters: [],
+                        count: 0,
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+describe('getFiltersFromQueryString', () => {
+    test('Extracts filters correctly and ignores invalid query string keys', () => {
+        const query = querystring.parse(
+            '?s=&language=Java&foo=bar&sortMode=0'
+        ) as ParsedUrlQuery;
+        const filters = getFiltersFromQueryStr(query, mockFilterItems);
+
+        expect(filters.length).toBe(1);
+        expect(filters[0].type).toBe('ProgrammingLanguage');
+        expect(filters[0].name).toBe('Java');
+    });
+
+    test('Mulitple filters with the same key are handled correctly', () => {
+        const query = querystring.parse(
+            'language=Java&language=Python&language=JavaScript'
+        ) as ParsedUrlQuery;
+        console.log(query);
+        const filters = getFiltersFromQueryStr(query, mockFilterItems);
+
+        expect(filters.length).toBe(3);
+        expect([...new Set(filters.map(x => x.type))].length).toBe(1); // Assert all filters have same type
+        expect(filters.some(x => x.name === 'Java')).toBeTruthy();
+        expect(filters.some(x => x.name === 'Python')).toBeTruthy();
+        expect(filters.some(x => x.name === 'JavaScript')).toBeTruthy();
+    });
+
+    test('L2 filters are extracted correctly', () => {
+        const query = querystring.parse(
+            'product=Schema&product=Atlas'
+        ) as ParsedUrlQuery;
+        const filters = getFiltersFromQueryStr(query, mockFilterItems);
+
+        expect(filters.length).toBe(2);
+        expect(filters.find(x => x.type === 'L2Product')?.name).toBe('Schema');
+        expect(filters.find(x => x.type === 'L1Product')?.name).toBe('Atlas');
+    });
+
+    test('Invalid query keys produce no filter results', () => {
+        const query = querystring.parse(
+            'foo=bar&asd=fgh&abc=def'
+        ) as ParsedUrlQuery;
+        const filters = getFiltersFromQueryStr(query, mockFilterItems);
+        expect(filters.length).toBe(0);
+    });
+
+    test('Invalid input produces no filter results', () => {
+        const query = querystring.parse('abcdef123456!@#$%^') as ParsedUrlQuery;
+        const filters = getFiltersFromQueryStr(query, mockFilterItems);
+        expect(filters.length).toBe(0);
+    });
+});
+
+const mockReplaceState = jest.fn();
+
+describe('updateUrl', () => {
+    beforeEach(() => {
+        mockReplaceState.mockClear();
+        window.history.replaceState = mockReplaceState;
+    });
+
+    test('Updates URL correctly with L1 filters', () => {
+        const filterItems = [
+            {
+                name: 'Java',
+                type: 'ProgrammingLanguage',
+                subFilters: [],
+                count: 0,
+            },
+            {
+                name: 'Nodejs',
+                type: 'Technology',
+                subFilters: [],
+                count: 0,
+            },
+        ] as FilterItem[];
+
+        updateUrl('/path', filterItems, 'test');
+
+        const calledUrl = mockReplaceState.mock.calls[0][2];
+        expect(calledUrl).toBe(
+            '/developer/path/?s=test&language=Java&technology=Nodejs&sortMode=0'
+        );
+    });
+
+    test('Updates URL correctly with L2 filters', () => {
+        const filterItems = [
+            {
+                name: 'Nodejs',
+                type: 'Technology',
+                subFilters: [],
+                count: 0,
+            },
+            {
+                name: 'Schema',
+                type: 'L2Product',
+                subFilters: [],
+                count: 0,
+            },
+            {
+                name: 'Snippet',
+                type: 'CodeLevel',
+                subFilters: [],
+                count: 0,
+            },
+        ] as FilterItem[];
+
+        updateUrl('/path', filterItems, 'test');
+
+        const calledUrl = mockReplaceState.mock.calls[0][2];
+        expect(calledUrl).toBe(
+            '/developer/path/?s=test&technology=Nodejs&product=Schema&exampleType=Snippet&sortMode=0'
+        );
+    });
 });

--- a/src/hooks/search/utils.ts
+++ b/src/hooks/search/utils.ts
@@ -1,18 +1,24 @@
 import { Fetcher } from 'swr';
-import { NextRouter } from 'next/router';
 
 import getAllSearchContent from '../../api-requests/get-all-search-content';
 import { PillCategory } from '../../types/pill-category';
 import { defaultSortByType, SearchItem } from '../../components/search/types';
 import { FilterItem } from '@mdb/devcenter-components';
-import { Tag } from '../../interfaces/tag';
 import { ContentItem } from '../../interfaces/content-item';
 import { Image } from '../../interfaces/image';
 import { Author } from '../../interfaces/author';
 import { getURLPath } from '../../utils/format-url-path';
 import { SortByType } from '../../components/search/types';
 import { sortByOptions } from '../../components/search/utils';
-import { CONTENT_TYPE_NAME_MAP } from '../../data/constants';
+import {
+    FILTER_ITEM_MODEL,
+    FILTER_ITEM_QUERY_MAP,
+    FILTER_ITEM_SUBFILTER_MAP,
+    FILTER_ITEM_TYPE_MAP,
+} from '../../data/constants';
+import { ParsedUrlQuery } from 'querystring';
+import { Tag } from '../../interfaces/tag';
+import { TagType } from '../../types/tag-type';
 
 export const searchItemToContentItem = ({
     type,
@@ -53,184 +59,156 @@ export const searchItemToContentItem = ({
     };
 };
 
-export const getFilters = async (
-    contentType?: PillCategory,
-    allSearchContent?: SearchItem[]
-) => {
-    const allFilters = contentType === undefined;
-    const allContent: SearchItem[] =
-        allSearchContent || (await getAllSearchContent());
-    const filterItems: FilterItem[] = [];
-
-    allContent.forEach(({ tags, type }) => {
-        tags.forEach(tag => {
-            if (!tag.name) return; // Short circuit if the tag name is null.
-            if (tag.type === 'L2Product') {
-                const l2FilterItem: FilterItem = {
-                    type: tag.type,
-                    name: tag.name,
-                    subFilters: [],
-                    count: allFilters || type === contentType ? 1 : 0,
-                };
-                const l1 = tags.filter(tag => tag.type === 'L1Product')[0]; // There should always be an L1 on a piece with an L2 tag.
-                const l1FilterItem = filterItems.find(
-                    item => item.type === 'L1Product' && item.name === l1.name
-                );
-                if (l1FilterItem) {
-                    // If L1 exists, check if L2 is attached to it yet.
-                    const existingL2 = l1FilterItem.subFilters?.find(
-                        subFilter =>
-                            l2FilterItem.name === subFilter.name &&
-                            l2FilterItem.type === subFilter.type
-                    );
-                    if (existingL2) {
-                        // If L2 is already attached, only bump the count (if the content type matches).
-                        if (
-                            (allFilters || type === contentType) &&
-                            existingL2.count
-                        ) {
-                            existingL2.count++;
-                        }
-                        return;
-                    }
-                    return l1FilterItem.subFilters?.push(l2FilterItem); // If L2 is not yet attached, attach it.
-                } else {
-                    // If the L1 doesn't exist, neither does the L2, so create L1 and add new L2 to it.
-                    const l1FilterItem: FilterItem = {
-                        type: l1.type,
-                        name: l1.name,
-                        subFilters: [l2FilterItem],
-                        count: allFilters || type === contentType ? 1 : 0,
-                    };
-                    return filterItems.push(l1FilterItem);
-                }
-            } else if (tag.type === 'CodeLevel') {
-                // Basically repeating the logic for L2s, can probably be separated and reused.
-                const codeLevelItem: FilterItem = {
-                    type: tag.type,
-                    name: tag.name,
-                    count: allFilters || type === contentType ? 1 : 0,
-                    subFilters: [],
-                };
-                const codeExampleFilterItem = filterItems.find(
-                    item =>
-                        item.type === 'ContentType' &&
-                        item.name === 'Code Example'
-                );
-                if (codeExampleFilterItem) {
-                    // If code examples tag already exists, check if this code level is attached.
-                    const existingCodeLevel =
-                        codeExampleFilterItem.subFilters?.find(
-                            subFilter =>
-                                codeLevelItem.name === subFilter.name &&
-                                codeLevelItem.type === codeLevelItem.type
-                        );
-                    if (existingCodeLevel) {
-                        // If code level is already attached, only bump the count (if the content type matches).
-                        if (
-                            (allFilters || type === contentType) &&
-                            existingCodeLevel.count
-                        ) {
-                            existingCodeLevel.count++;
-                        }
-                        return;
-                    }
-                    return codeExampleFilterItem.subFilters?.push(
-                        codeLevelItem
-                    );
-                } else {
-                    // If the Code Example tag doesn't exist, neither does the L2, so create L1 and add new L2 to it.
-                    const codeExampleFilterItem: FilterItem = {
-                        type: 'ContentType',
-                        name: 'Code Example',
-                        subFilters: [codeLevelItem],
-                        count: allFilters || type === contentType ? 1 : 0,
-                    };
-                    return filterItems.push(codeExampleFilterItem);
-                }
-            } else {
-                // For everything else, just check if it exists.
-                const existingItem = filterItems.find(
-                    filter =>
-                        filter.name === tag.name && filter.type === tag.type
-                );
-                if (existingItem) {
-                    // If it exists, increment count only if the content type matches.
-                    if (
-                        (allFilters || type === contentType) &&
-                        existingItem.count
-                    ) {
-                        existingItem.count++;
-                    }
-                    return;
-                } else {
-                    // If not, add it to the list.
-                    const filterItem: FilterItem = {
-                        type: tag.type,
-                        name: tag.name,
-                        count: allFilters || type === contentType ? 1 : 0,
-                        subFilters: [],
-                    };
-                    return filterItems.push(filterItem);
-                }
-            }
-        });
+export const fetcher: Fetcher<ContentItem[], string> = queryString => {
+    return fetch(
+        (getURLPath('/api/search') as string) + '?' + queryString
+    ).then(async response => {
+        const r_json: SearchItem[] = await response.json();
+        return r_json.map(searchItemToContentItem);
     });
+};
 
-    // Sort everything by count.
+const tagToFilter = ({ name, type }: Tag): FilterItem => ({
+    name,
+    type,
+    subFilters: [],
+    count: 0,
+});
 
-    // Sort sub items.
+const itemMatches = (item1: FilterItem | Tag, item2: FilterItem | Tag) =>
+    item1.name === item2.name && item1.type === item2.type;
 
-    const sortFunction = (prev: FilterItem, next: FilterItem) =>
-        (next.count || 0) - (prev.count || 0);
+const itemId = (item: FilterItem | Tag, parent?: FilterItem | Tag) =>
+    `${item.name},${item.type}` +
+    (parent ? `,${parent.name},${parent.type}` : '');
 
-    filterItems.forEach(item => {
-        if (item.subFilters?.length) {
-            item.subFilters.sort(
-                (prev, next) => (next.count || 0) - (prev.count || 0)
+const sortFilterItems = (items: FilterItem[]) => {
+    if (!items.length) return;
+
+    // Sort L2 items (subFilters) by count
+    items.forEach(({ subFilters }) => {
+        if (subFilters) {
+            subFilters.sort((a: FilterItem, b: FilterItem) =>
+                (a?.count || -1) < (b?.count || -1) ? 1 : -1
             );
         }
     });
 
-    const orderedFilterItems = [];
-
-    Object.keys(CONTENT_TYPE_NAME_MAP).forEach(key => {
-        const items = filterItems
-            .filter(({ type }) => type === key)
-            .sort(sortFunction);
-
-        if (items.length) {
-            orderedFilterItems.push({ key, value: items });
-        }
-    });
-
-    // Parse the code levels from the subitmes of the Code Example content type filter.
-    const codeLevelItems =
-        filterItems
-            .filter(
-                item =>
-                    item.type === 'ContentType' && item.name === 'Code Example'
-            )?.[0]
-            ?.subFilters?.sort(sortFunction) || [];
-
-    if (!!codeLevelItems.length && contentType === 'Code Example') {
-        orderedFilterItems.unshift({
-            key: 'ExampleType',
-            value: codeLevelItems,
-        });
-    }
-
-    return orderedFilterItems;
+    // Sort L1 items by count
+    items.sort((a: FilterItem, b: FilterItem) =>
+        (a?.count || -1) < (b?.count || -1) ? 1 : -1
+    );
 };
 
-const itemInFilterGroup = (tags: Tag[], filters: FilterItem[]) => {
-    // This is inclusive within filter groups. If you check Python and C#, you get both Python and C# content.
-    if (!filters.length) return true;
-    return tags.some(tag =>
-        filters.some(
-            filter => filter.name === tag.name && filter.type === tag.type
-        )
-    );
+// Business logic/one-offs to ensure improperly tagged content doesn't end up in the filter list
+const fixForImproperlyTaggedContent = (filterItems: FilterItem[]) => {
+    const fixCodeLevelSubFilters = (item: FilterItem) => {
+        const filtered =
+            item.subFilters?.filter(tag => tag.type !== 'CodeLevel') || [];
+
+        if (
+            filtered.length !== item.subFilters?.length &&
+            !(item.type === 'ContentType' && item.name === 'Code Example')
+        ) {
+            item.subFilters = filtered;
+        }
+    };
+
+    filterItems.forEach((item: FilterItem) => {
+        fixCodeLevelSubFilters(item);
+
+        // ...add more here if needed
+    });
+};
+
+export const getFilters = async (
+    contentType?: PillCategory,
+    allSearchContent?: SearchItem[]
+) => {
+    const allContent: SearchItem[] =
+        allSearchContent || (await getAllSearchContent());
+
+    const itemFreqMap: { [id: string]: number } = {};
+
+    // First pass, construct all first level filters
+    const filterItems = allContent.flatMap(({ tags, type: itemType }) => {
+        const matchingType =
+            contentType === itemType || contentType === undefined;
+
+        return tags.flatMap(tag => {
+            const itemModel = FILTER_ITEM_TYPE_MAP[tag.type || ''];
+
+            const checkForContentType =
+                ((itemModel?.forContentType &&
+                    itemModel?.forContentType !== contentType) ||
+                    (contentType && itemModel?.forContentType === '')) &&
+                contentType !== undefined; // All filters should be shown on sitewide search
+
+            const id = itemId(tag);
+            const itemFreq = itemFreqMap[id];
+            const newItem = !itemFreq && itemFreq !== 0;
+
+            if (matchingType) {
+                itemFreqMap[id] = newItem ? 1 : itemFreq + 1;
+            } else if (newItem) {
+                // If the content type doesn't match, we still want to display,
+                // but set the frequency to 0 to push to the bottom of the list
+                itemFreqMap[id] = 0;
+            }
+
+            if (!itemModel || checkForContentType || !newItem) return [];
+
+            return [tagToFilter(tag)];
+        });
+    });
+
+    // Second pass, add in the second level filters
+    allContent.forEach(({ tags }) => {
+        tags.forEach(tag => {
+            const parentType = FILTER_ITEM_SUBFILTER_MAP[tag.type];
+
+            if (!parentType) return;
+
+            const matchingTag = tags.find(tag => tag.type === parentType);
+            const parentFilterItem =
+                matchingTag &&
+                filterItems.find(item => itemMatches(item, matchingTag));
+
+            if (!parentFilterItem) return;
+
+            const existingSubFilter = parentFilterItem.subFilters?.find(item =>
+                itemMatches(item, tag)
+            );
+
+            if (!existingSubFilter) {
+                parentFilterItem.subFilters?.push(tagToFilter(tag));
+            }
+        });
+    });
+
+    // Update the counts on all filter items & sub filter items based on the frequency map
+    filterItems.forEach(item => {
+        item.subFilters?.forEach(subItem => {
+            subItem.count = itemFreqMap[itemId(subItem)] || 0;
+        });
+
+        item.count = itemFreqMap[itemId(item)] || 0;
+    });
+
+    fixForImproperlyTaggedContent(filterItems);
+
+    // Sort by count and convert to an object that the Filter components are able to display
+    return FILTER_ITEM_MODEL.flatMap(model => {
+        const matchingItems = filterItems.filter(
+            item => item.type === model.type
+        );
+
+        sortFilterItems(matchingItems);
+
+        return matchingItems.length
+            ? [{ key: model.displayName, value: matchingItems }]
+            : [];
+    });
 };
 
 export const hasEmptyFilterAndQuery = (
@@ -248,99 +226,83 @@ export const itemInFilters = (
     { tags }: ContentItem,
     allFilters: FilterItem[]
 ) => {
-    // This is exclusive between filter groups. If you check Python and Atlas, you only get things that are both Pyhton and Atlas,
-    // not everythign Pyhton and everything Atlas.
-    const productFilters = allFilters.filter(
-        ({ type }) => type === 'L1Product' || type === 'L2Product'
-    );
-    const languageFilters = allFilters.filter(
-        ({ type }) => type === 'ProgrammingLanguage'
-    );
-    const techFilters = allFilters.filter(({ type }) => type === 'Technology');
-    const expertiseFilters = allFilters.filter(
-        ({ type }) => type === 'ExpertiseLevel'
-    );
-    const contributedByFilters = allFilters.filter(
-        ({ type }) => type === 'AuthorType'
-    );
-    const contentTypeFilters = allFilters.filter(
-        ({ type }) => type === 'ContentType'
-    );
-    const codeLevelFilters = allFilters.filter(
-        ({ type }) => type === 'CodeLevel'
-    );
-    return (
-        itemInFilterGroup(tags, productFilters) &&
-        itemInFilterGroup(tags, languageFilters) &&
-        itemInFilterGroup(tags, techFilters) &&
-        itemInFilterGroup(tags, expertiseFilters) &&
-        itemInFilterGroup(tags, contributedByFilters) &&
-        itemInFilterGroup(tags, contentTypeFilters) &&
-        itemInFilterGroup(tags, codeLevelFilters)
-    );
-};
+    if (!allFilters.length) return true;
 
-export const fetcher: Fetcher<ContentItem[], string> = queryString => {
-    return fetch(
-        (getURLPath('/api/search') as string) + '?' + queryString
-    ).then(async response => {
-        const r_json: SearchItem[] = await response.json();
-        return r_json.map(searchItemToContentItem);
-    });
+    return tags.some(tag =>
+        allFilters.some(
+            filter => filter.name === tag.name && filter.type === tag.type
+        )
+    );
 };
 
 export const updateUrl = (
-    router: NextRouter,
+    pathname: string,
     filters: FilterItem[],
     searchString: string,
-    sortBy?: SortByType
+    sortBy?: SortByType | ''
 ) => {
-    if (!sortBy) {
-        sortBy = defaultSortByType;
-    }
-    // Have to preserve the filters here as well.
-    const product = filters
-        .filter(
-            filter => filter.type === 'L1Product' || filter.type === 'L2Product'
-        )
-        .map(filter => filter.name);
-    const language = filters
-        .filter(filter => filter.type === 'ProgrammingLanguage')
-        .map(filter => filter.name);
-    const technology = filters
-        .filter(filter => filter.type === 'Technology')
-        .map(filter => filter.name);
-    const contentType = filters
-        .filter(
-            filter =>
-                filter.type === 'ContentType' || filter.type === 'CodeLevel'
-        )
-        .map(filter => filter.name);
-    const contributedBy = filters
-        .filter(filter => filter.type === 'AuthorType')
-        .map(filter => filter.name);
-    const expertiseLevel = filters
-        .filter(filter => filter.type === 'ExpertiseLevel')
-        .map(filter => filter.name);
+    // Build an array of pairs of query string keys and values
+    const filterParams = filters.reduce((acc: [string, string][], filter) => {
+        if (!filter.type) return acc;
 
-    const all = {
-        product,
-        language,
-        technology,
-        contentType,
-        contributedBy,
-        expertiseLevel,
-    } as { [key: string]: string[] };
-    const params = new URLSearchParams({ s: searchString });
+        const l1Query = FILTER_ITEM_TYPE_MAP[filter.type]?.query;
+        const l2Query = FILTER_ITEM_MODEL.find(x =>
+            x.subFilters?.includes((filter.type || '') as TagType)
+        )?.query;
+        const query = l1Query || l2Query;
 
-    Object.keys(all).forEach(key => {
-        if (all[key].length) {
-            all[key].forEach(value => params.append(key, value));
-        }
-    });
+        return query ? [...acc, [query, filter.name]] : acc;
+    }, []) as [string, string][];
 
-    params.append('sortMode', sortByOptions[sortBy as SortByType].toString());
-    replaceHistoryState(`/developer${router.pathname}/?${params.toString()}`);
+    const params = new URLSearchParams([
+        ['s', searchString],
+        ...filterParams,
+        ['sortMode', sortByOptions[sortBy || defaultSortByType].toString()],
+    ]);
+
+    replaceHistoryState(`/developer${pathname}/?${params.toString()}`);
+};
+
+export const getFiltersFromQueryStr = (
+    query: ParsedUrlQuery,
+    filterItems: { key: string; value: FilterItem[] }[]
+) => {
+    /*
+        Pick out the valid query string keys, and return a mapping from their associated types to the query string values as an array
+        e.g. a query string of 'language=Java&foo=bar' would transform to { 'ProgrammingLanguage': ['Java'] } (filtering out the invalid qs)
+        Multiple of the same key: 'language=Java&language=Python' -> { 'ProgrammingLanguage': ['Java', 'Python'] }
+        Types with subFilters are duplicated with the subFilter: 'product=Schema' -> { L1Product: ['Schema'], L2Product: ['Schema']}
+    */
+    const filterTypeMap = Object.keys(query).reduce((acc, qs) => {
+        const model = FILTER_ITEM_QUERY_MAP[qs];
+        if (!model) return acc;
+
+        const queryValue = Array.isArray(query[qs]) ? query[qs] : [query[qs]];
+        const subFilterMap =
+            model.subFilters?.reduce(
+                (a, v) => ({ ...a, [v]: queryValue }),
+                {}
+            ) || {};
+
+        return { ...acc, [model.type]: queryValue, ...subFilterMap };
+    }, {}) as { [type: string]: string[] };
+
+    // Flatten filterItems into a 1D array containing all L1 and L2 filters
+    const allFiltersAndSubFilters = filterItems.reduce(
+        (acc: FilterItem[], item: { key: string; value: FilterItem[] }) => [
+            ...acc,
+            ...item.value,
+            ...(item.value.flatMap(x => x.subFilters) as FilterItem[]),
+        ],
+        []
+    );
+
+    // Return filters that have matching type/names with the provided query string type/values
+    return allFiltersAndSubFilters.filter(item =>
+        item.type && filterTypeMap[item.type]
+            ? filterTypeMap[item.type].includes(item.name)
+            : false
+    );
 };
 
 /* 

--- a/src/page-templates/content-type-page/content-type-data.ts
+++ b/src/page-templates/content-type-page/content-type-data.ts
@@ -29,10 +29,7 @@ export const getContentTypePageData = async (
         Sentry.captureException(e);
     }
 
-    // Pop contentTypeItems out of here becasue we don't filter by it for these pages.
-    const filterItems = (
-        await getFilters(contentType, allSearchContent)
-    ).filter(item => item.key !== 'ContentType');
+    const filterItems = await getFilters(contentType, allSearchContent);
 
     const metaInfoForTopic = await getMetaInfoForTopic(slug);
     const description = metaInfoForTopic?.description


### PR DESCRIPTION
## Jira Ticket:

[[DEVHUB-1609] Refactor Filtering Logic to be Generic](https://jira.mongodb.org/browse/DEVHUB-1609)

## Description:
Was going to put this in my events PR but decided to cherry pick it to a separate branch/PR since that PR is getting huge. 

While adding some of the filter/query string logic for events, it felt wrong to add another one-off if statement, so I decided to do some refactoring of the utils to make them completely generic. Now, the source of truth lies in a constant `FILTER_ITEM_MODEL` which declares the order of the filters, the section header names, which filters show on which pages, and which filters group together (L2 items).

Now adding a new filter section should only involve adding an item to the `FILTER_ITEM_MODEL` constant. Also, I felt like these functions could use some tests so I added those as well.

## Related Issue(s) or Dependencies (if applicable):

Please link to the issue(s) or dependencies here

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Recordit](https://recordit.co/) app or [Quicktime](https://apple.co/2J1EWUD) screen recorder
