### PR TITLE
[DEVHUB-1633] Refactor getAllMetaInfo calls to use pre-val

### DIFF
--- a/src/pages/languages.tsx
+++ b/src/pages/languages.tsx
@@ -12,7 +12,7 @@ import {
 import { Grid, ThemeUICSSObject } from 'theme-ui';
 
 import { languageToLogo } from '../utils/language-to-logo';
-import { getAllMetaInfo } from '../service/get-all-meta-info';
+import allMetaInfoPreval from '../service/get-all-meta-info.preval';
 import { MetaInfo } from '../interfaces/meta-info';
 import { getURLPath } from '../utils/format-url-path';
 import { h4Styles, h5Styles } from '../styled/layout';
@@ -167,9 +167,7 @@ export const getStaticProps: GetStaticProps<{
     languages: MetaInfo[];
     featured: MetaInfo[];
 }> = async () => {
-    const tags = await getAllMetaInfo();
-
-    const languages = tags.filter(
+    const languages = allMetaInfoPreval.filter(
         tag => tag.category === 'ProgrammingLanguage'
     );
 

--- a/src/pages/products.tsx
+++ b/src/pages/products.tsx
@@ -16,7 +16,7 @@ import { Crumb } from '../components/breadcrumbs/types';
 import { getURLPath } from '../utils/format-url-path';
 import { productToLogo } from '../utils/product-to-logo';
 
-import { getAllMetaInfo } from '../service/get-all-meta-info';
+import allMetaInfoPreval from '../service/get-all-meta-info.preval';
 import { MetaInfo } from '../interfaces/meta-info';
 
 import { h4Styles, h5Styles } from '../styled/layout';
@@ -203,10 +203,12 @@ const ProductsPage: NextPage<ProductsPageProps> = ({ products, featured }) => (
 export default ProductsPage;
 
 export const getStaticProps: GetStaticProps = async () => {
-    const tags = await getAllMetaInfo();
-
-    const l1Products = tags.filter(tag => tag.category === 'L1Product');
-    const l2Products = tags.filter(tag => tag.category === 'L2Product');
+    const l1Products = allMetaInfoPreval.filter(
+        tag => tag.category === 'L1Product'
+    );
+    const l2Products = allMetaInfoPreval.filter(
+        tag => tag.category === 'L2Product'
+    );
 
     const products: L1Product[] = l1Products.map(prod => ({
         ...prod,

--- a/src/pages/technologies.tsx
+++ b/src/pages/technologies.tsx
@@ -6,7 +6,7 @@ import { GridLayout, LogoPaths, BrandedIcon, ThirdPartyLogo } from '@mdb/flora';
 import { Grid } from 'theme-ui';
 
 import { technologyToLogo } from '../utils/technology-to-logo';
-import { getAllMetaInfo } from '../service/get-all-meta-info';
+import allMetaInfoPreval from '../service/get-all-meta-info.preval';
 import { MetaInfo } from '../interfaces/meta-info';
 import TopicCard from '../components/topic-card';
 import { iconStyles } from '../components/topic-card/styles';
@@ -87,8 +87,7 @@ export default TechnologiesPage;
 export const getStaticProps: GetStaticProps<{
     technologies: MetaInfo[];
 }> = async () => {
-    const tags = await getAllMetaInfo();
-    const technologies = tags
+    const technologies = allMetaInfoPreval
         .filter(tag => tag.category === 'Technology')
         .sort((prev, next) =>
             prev.tagName.toLowerCase().localeCompare(next.tagName.toLowerCase())

--- a/src/pages/topics.tsx
+++ b/src/pages/topics.tsx
@@ -1,6 +1,6 @@
 import { GetStaticProps } from 'next';
 import { NextSeo } from 'next-seo';
-import { getAllMetaInfo } from '../service/get-all-meta-info';
+import allMetaInfoPreval from '../service/get-all-meta-info.preval';
 import { getURLPath } from '../utils/format-url-path';
 import Hero from '../components/hero';
 import { Crumb } from '../components/breadcrumbs/types';
@@ -219,8 +219,7 @@ const Topic = ({ topics }: { topics: TopicsProps[] }) => {
 export default Topic;
 
 export const getStaticProps: GetStaticProps = async () => {
-    const metaInfo = await getAllMetaInfo();
     return {
-        props: { topics: metaInfo },
+        props: { topics: allMetaInfoPreval },
     };
 };

--- a/src/pages/topics.tsx
+++ b/src/pages/topics.tsx
@@ -218,8 +218,6 @@ const Topic = ({ topics }: { topics: TopicsProps[] }) => {
 
 export default Topic;
 
-export const getStaticProps: GetStaticProps = async () => {
-    return {
-        props: { topics: allMetaInfoPreval },
-    };
-};
+export const getStaticProps: GetStaticProps = async () => ({
+    props: { topics: allMetaInfoPreval },
+});

--- a/src/service/get-subtopics.ts
+++ b/src/service/get-subtopics.ts
@@ -1,8 +1,7 @@
-import { getAllMetaInfo } from './get-all-meta-info';
+import allMetaInfoPreval from '../service/get-all-meta-info.preval';
 
 export const getSubtopics = async (topic: string) => {
-    const metaInfo = await getAllMetaInfo();
-    const metaInfoForTopicName = metaInfo.filter(
+    const metaInfoForTopicName = allMetaInfoPreval.filter(
         m => m.tagName.toLowerCase() === topic.toLowerCase()
     );
     return metaInfoForTopicName.length > 0

--- a/src/service/get-subtopics.ts
+++ b/src/service/get-subtopics.ts
@@ -1,4 +1,4 @@
-import allMetaInfoPreval from '../service/get-all-meta-info.preval';
+import allMetaInfoPreval from './get-all-meta-info.preval';
 
 export const getSubtopics = async (topic: string) => {
     const metaInfoForTopicName = allMetaInfoPreval.filter(


### PR DESCRIPTION
## Jira Ticket:

[[DEVHUB-1633] Refactor getAllMetaInfo calls to use pre-val](https://jira.mongodb.org/browse/DEVHUB-1633)

## Description:

Changed all `getAllMetaInfo` calls to use the preval'd version

## Related Issue(s) or Dependencies (if applicable):

Please link to the issue(s) or dependencies here

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Recordit](https://recordit.co/) app or [Quicktime](https://apple.co/2J1EWUD) screen recorder
