### PR TITLE
[DEVHUB-1641...1644] UAT Events Fixes

### DIFF
--- a/src/hooks/search/location.ts
+++ b/src/hooks/search/location.ts
@@ -24,7 +24,7 @@ const useLocationSearch = (callback: () => void) => {
     const [geolocationValidating, setGeolocationValidating] = useState(false);
 
     const {
-        data: rawLocationResults = [],
+        data: locationResults = [],
         isValidating: locationValidating,
     }: {
         data?: google.maps.places.AutocompletePrediction[];
@@ -33,17 +33,6 @@ const useLocationSearch = (callback: () => void) => {
         locationQuery ? `search=${locationQuery}` : null,
         locationFetcher,
         swrOptions
-    );
-
-    // Remove large result types since we're comparing coordinates
-    const locationResults = useMemo(
-        () =>
-            rawLocationResults?.filter(
-                res =>
-                    !res.types.includes('country') &&
-                    !res.types.includes('continent')
-            ),
-        [rawLocationResults]
     );
 
     const onLocationQuery = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/hooks/search/location.ts
+++ b/src/hooks/search/location.ts
@@ -23,10 +23,27 @@ const useLocationSearch = (callback: () => void) => {
         useState<LocationSelection>();
     const [geolocationValidating, setGeolocationValidating] = useState(false);
 
-    const { data: locationResults, isValidating: locationValidating } = useSWR(
+    const {
+        data: rawLocationResults = [],
+        isValidating: locationValidating,
+    }: {
+        data?: google.maps.places.AutocompletePrediction[];
+        isValidating: boolean;
+    } = useSWR(
         locationQuery ? `search=${locationQuery}` : null,
         locationFetcher,
         swrOptions
+    );
+
+    // Remove large result types since we're comparing coordinates
+    const locationResults = useMemo(
+        () =>
+            rawLocationResults?.filter(
+                res =>
+                    !res.types.includes('country') &&
+                    !res.types.includes('continent')
+            ),
+        [rawLocationResults]
     );
 
     const onLocationQuery = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/hooks/search/utils.test.tsx
+++ b/src/hooks/search/utils.test.tsx
@@ -453,12 +453,12 @@ describe('itemInFilters', () => {
         const itemWithBothTags = {
             tags: [
                 {
-                    name: 'filter1',
+                    name: 'tag1',
                     slug: 'slug',
                     type: 'type1',
                 },
                 {
-                    name: 'filter2',
+                    name: 'tag2',
                     slug: 'slug',
                     type: 'type2',
                 },
@@ -468,7 +468,7 @@ describe('itemInFilters', () => {
         const itemWithOneTag = {
             tags: [
                 {
-                    name: 'filter1',
+                    name: 'tag1',
                     slug: 'slug',
                     type: 'type1',
                 },
@@ -478,13 +478,13 @@ describe('itemInFilters', () => {
         const filters = [
             {
                 count: 0,
-                name: 'filter1',
+                name: 'tag1',
                 subFilters: [],
                 type: 'type1',
             },
             {
                 count: 0,
-                name: 'filter2',
+                name: 'tag2',
                 subFilters: [],
                 type: 'type2',
             },
@@ -498,12 +498,12 @@ describe('itemInFilters', () => {
         const itemWithBothTags = {
             tags: [
                 {
-                    name: 'filter1',
+                    name: 'tag1',
                     slug: 'slug',
                     type: 'type1',
                 },
                 {
-                    name: 'filter2',
+                    name: 'tag2',
                     slug: 'slug',
                     type: 'type1',
                 },
@@ -513,12 +513,12 @@ describe('itemInFilters', () => {
         const itemWithFirstTag = {
             tags: [
                 {
-                    name: 'filter1',
+                    name: 'tag1',
                     slug: 'slug',
                     type: 'type1',
                 },
                 {
-                    name: 'filter2',
+                    name: 'tag2',
                     slug: 'slug',
                     type: 'type2',
                 },
@@ -528,12 +528,12 @@ describe('itemInFilters', () => {
         const itemWithSecondTag = {
             tags: [
                 {
-                    name: 'filter2',
+                    name: 'tag1',
                     slug: 'slug',
                     type: 'type1',
                 },
                 {
-                    name: 'filter3',
+                    name: 'tag3',
                     slug: 'slug',
                     type: 'type3',
                 },
@@ -543,13 +543,13 @@ describe('itemInFilters', () => {
         const filters = [
             {
                 count: 0,
-                name: 'filter1',
+                name: 'tag1',
                 subFilters: [],
                 type: 'type1',
             },
             {
                 count: 0,
-                name: 'filter2',
+                name: 'tag2',
                 subFilters: [],
                 type: 'type1',
             },
@@ -558,5 +558,93 @@ describe('itemInFilters', () => {
         expect(itemInFilters(itemWithBothTags, filters)).toBe(true);
         expect(itemInFilters(itemWithFirstTag, filters)).toBe(true);
         expect(itemInFilters(itemWithSecondTag, filters)).toBe(true);
+    });
+
+    test('Two filters of the same type and one of a different type use both AND and OR logic', () => {
+        const itemWithOneTag = {
+            tags: [
+                {
+                    name: 'tag3',
+                    slug: 'slug',
+                    type: 'type2',
+                },
+            ],
+        } as unknown as ContentItem;
+
+        const itemWithSameTypeTags = {
+            tags: [
+                {
+                    name: 'tag1',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+                {
+                    name: 'tag2',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+            ],
+        } as unknown as ContentItem;
+
+        const itemWithDifferentTypeTags = {
+            tags: [
+                {
+                    name: 'tag1',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+                {
+                    name: 'tag3',
+                    slug: 'slug',
+                    type: 'type2',
+                },
+            ],
+        } as unknown as ContentItem;
+
+        const itemWithAllTags = {
+            tags: [
+                {
+                    name: 'tag1',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+                {
+                    name: 'tag2',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+                {
+                    name: 'tag3',
+                    slug: 'slug',
+                    type: 'type2',
+                },
+            ],
+        } as unknown as ContentItem;
+
+        const filters = [
+            {
+                count: 0,
+                name: 'tag1',
+                subFilters: [],
+                type: 'type1',
+            },
+            {
+                count: 0,
+                name: 'tag2',
+                subFilters: [],
+                type: 'type1',
+            },
+            {
+                count: 0,
+                name: 'tag3',
+                subFilters: [],
+                type: 'type2',
+            },
+        ];
+
+        expect(itemInFilters(itemWithOneTag, filters)).toBe(false);
+        expect(itemInFilters(itemWithSameTypeTags, filters)).toBe(false);
+        expect(itemInFilters(itemWithDifferentTypeTags, filters)).toBe(true);
+        expect(itemInFilters(itemWithAllTags, filters)).toBe(true);
     });
 });

--- a/src/hooks/search/utils.test.tsx
+++ b/src/hooks/search/utils.test.tsx
@@ -6,12 +6,14 @@ import {
     getFilters,
     getFiltersFromQueryStr,
     isEmptyArray,
+    itemInFilters,
     updateUrl,
 } from './utils';
 import { MOCK_ARTICLE_TAGS } from '../../mockdata/mock-tags';
 import { SearchItem } from '../../components/search/types';
 import { FilterItem } from '@mdb/devcenter-components';
 import querystring, { ParsedUrlQuery } from 'querystring';
+import { ContentItem } from '../../interfaces/content-item';
 
 test('correctly checks if array is empty', () => {
     expect(isEmptyArray([{}, {}])).toBeFalsy();
@@ -422,5 +424,139 @@ describe('updateUrl', () => {
         expect(calledUrl).toBe(
             '/developer/path/?s=test&technology=Nodejs&product=Schema&exampleType=Snippet&sortMode=0'
         );
+    });
+});
+
+describe('itemInFilters', () => {
+    test('If no filters are provided, it returns true', () => {
+        expect(itemInFilters({ tags: [] } as unknown as ContentItem, [])).toBe(
+            true
+        );
+    });
+
+    test('If no tags are provided with nonempty filters, it returns false', () => {
+        const filters = [
+            {
+                count: 0,
+                name: 'filter1',
+                subFilters: [],
+                type: 'type1',
+            },
+        ];
+
+        expect(
+            itemInFilters({ tags: [] } as unknown as ContentItem, filters)
+        ).toBe(false);
+    });
+
+    test('Two filters of different types use AND logic', () => {
+        const itemWithBothTags = {
+            tags: [
+                {
+                    name: 'filter1',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+                {
+                    name: 'filter2',
+                    slug: 'slug',
+                    type: 'type2',
+                },
+            ],
+        } as unknown as ContentItem;
+
+        const itemWithOneTag = {
+            tags: [
+                {
+                    name: 'filter1',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+            ],
+        } as unknown as ContentItem;
+
+        const filters = [
+            {
+                count: 0,
+                name: 'filter1',
+                subFilters: [],
+                type: 'type1',
+            },
+            {
+                count: 0,
+                name: 'filter2',
+                subFilters: [],
+                type: 'type2',
+            },
+        ];
+
+        expect(itemInFilters(itemWithBothTags, filters)).toBe(true);
+        expect(itemInFilters(itemWithOneTag, filters)).toBe(false);
+    });
+
+    test('Two filters of the same type use OR logic', () => {
+        const itemWithBothTags = {
+            tags: [
+                {
+                    name: 'filter1',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+                {
+                    name: 'filter2',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+            ],
+        } as unknown as ContentItem;
+
+        const itemWithFirstTag = {
+            tags: [
+                {
+                    name: 'filter1',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+                {
+                    name: 'filter2',
+                    slug: 'slug',
+                    type: 'type2',
+                },
+            ],
+        } as unknown as ContentItem;
+
+        const itemWithSecondTag = {
+            tags: [
+                {
+                    name: 'filter2',
+                    slug: 'slug',
+                    type: 'type1',
+                },
+                {
+                    name: 'filter3',
+                    slug: 'slug',
+                    type: 'type3',
+                },
+            ],
+        } as unknown as ContentItem;
+
+        const filters = [
+            {
+                count: 0,
+                name: 'filter1',
+                subFilters: [],
+                type: 'type1',
+            },
+            {
+                count: 0,
+                name: 'filter2',
+                subFilters: [],
+                type: 'type1',
+            },
+        ];
+
+        expect(itemInFilters(itemWithBothTags, filters)).toBe(true);
+        expect(itemInFilters(itemWithFirstTag, filters)).toBe(true);
+        expect(itemInFilters(itemWithSecondTag, filters)).toBe(true);
     });
 });

--- a/src/hooks/search/utils.ts
+++ b/src/hooks/search/utils.ts
@@ -273,9 +273,26 @@ export const itemInFilters = (
 ) => {
     if (!allFilters.length) return true;
 
-    return tags.some(tag =>
-        allFilters.some(
-            filter => filter.name === tag.name && filter.type === tag.type
+    // Group tags by their type
+    const allFiltersTypeMap: { [type: string]: FilterItem[] } = {};
+
+    allFilters.forEach((filter: FilterItem) => {
+        if (filter.type) {
+            if (!allFiltersTypeMap[filter.type]) {
+                allFiltersTypeMap[filter.type] = [filter];
+            } else {
+                allFiltersTypeMap[filter.type].push(filter);
+            }
+        }
+    });
+
+    // AND filters with different types, OR filters of the same type
+    return Object.values(allFiltersTypeMap).every((filters: FilterItem[]) =>
+        tags.some(tag =>
+            filters.some(
+                (filter: FilterItem) =>
+                    filter.name === tag.name && filter.type === tag.type
+            )
         )
     );
 };

--- a/src/hooks/search/utils.ts
+++ b/src/hooks/search/utils.ts
@@ -84,7 +84,10 @@ export const searchFetcher: Fetcher<ContentItem[], string> = queryString => {
     });
 };
 
-export const locationFetcher: Fetcher<any[], string> = queryString => {
+export const locationFetcher: Fetcher<
+    google.maps.places.AutocompletePrediction[],
+    string
+> = queryString => {
     return fetch(
         (getURLPath('/api/location') as string) + '?' + queryString
     ).then(async response => {

--- a/src/hooks/search/utils.ts
+++ b/src/hooks/search/utils.ts
@@ -139,15 +139,8 @@ const fixForImproperlyTaggedContent = (filterItems: FilterItem[]) => {
         }
     };
 
-    const fixAttendanceType = (item: FilterItem) => {
-        if (item.type === 'EventAttendance' && item.name === 'InPerson') {
-            item.name = 'In-Person';
-        }
-    };
-
     filterItems.forEach((item: FilterItem) => {
         fixCodeLevelSubFilters(item);
-        fixAttendanceType(item);
         // ...add more here if needed
     });
 };

--- a/src/page-templates/topic-content-type-page/topic-content-type-page-template.tsx
+++ b/src/page-templates/topic-content-type-page/topic-content-type-page-template.tsx
@@ -230,7 +230,7 @@ const TopicContentTypePageTemplate: NextPage<TopicContentTypePageProps> = ({
                 </TypographyScale>
                 <TypographyScale variant="body2">{description}</TypographyScale>
             </div>
-            {contentType !== 'News & Announcements' && (
+            {contentType !== 'News & Announcements' && contentType !== 'Event' && (
                 <div sx={CTAContainerStyles}>
                     <Button
                         onClick={() => setModalStage('text')}

--- a/src/pages/api/location.ts
+++ b/src/pages/api/location.ts
@@ -1,13 +1,25 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { withSentry } from '@sentry/nextjs';
 
+const LOCATION_TYPES = [
+    'locality',
+    'sublocality',
+    'postal_code',
+    'administrative_area_level_1',
+    'administrative_area_level_2',
+];
+
 async function locationSearchHandler(
     req: NextApiRequest,
     res: NextApiResponse
 ) {
     try {
         const request = await fetch(
-            `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${req.query.search}&types=(regions)&key=${process.env.GOOGLE_PLACES_API_KEY}`
+            `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${
+                req.query.search
+            }&types=${LOCATION_TYPES.join('|')}&key=${
+                process.env.GOOGLE_PLACES_API_KEY
+            }`
         );
 
         const { predictions = [], error_message = '' } = await request.json();

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -84,7 +84,7 @@ const EventsPageComponent: React.FunctionComponent<
     slug,
     contentType,
 }) => {
-    // TODO: Refactor and remove the following three lines
+    // TODO: Refactor and remove the following three consts
     const filters = useMemo(
         () => fixInPersonFilter(filterProps.filters),
         [filterProps.filters]


### PR DESCRIPTION
## Jira Ticket:

[DEVHUB-1641](https://jira.mongodb.org/browse/DEVHUB-1641)
[DEVHUB-1642](https://jira.mongodb.org/browse/DEVHUB-1642)
[DEVHUB-1643](https://jira.mongodb.org/browse/DEVHUB-1643)
[DEVHUB-1644](https://jira.mongodb.org/browse/DEVHUB-1644)

## Description:

- Remove Events CTA on Events Topic Content Type pages
- Filter out countries and continents from location search results
- Fix filtering logic. Everything was ORing before, now only filters within each filter group OR, while filters between different filter groups AND (this was the previous behavior in production, this PR should restore that behavior)
- Fix "In-Person" filter bug introduced by previous PR where no results would show up

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added tests that prove my fix is effective or that my feature works
