### PR TITLE
[DEVHUB-1653]: Industry Events Page Shows Parent Events With Child Events In Tertiary Nav

### DIFF
--- a/src/page-templates/content-page/content-page-data.ts
+++ b/src/page-templates/content-page/content-page-data.ts
@@ -50,13 +50,14 @@ export const getContentPageData = async (slug: string[]) => {
             sideNavFilterSlug = contentItem.primaryTag.l1Product.calculatedSlug;
         }
     } else if (isEventContent) {
-        // Events do not come with a "primary tag" fields, so a search for "L1Product" needs to be done in the standard tags field
-        const eventL1Product = contentItem.tags.find(
-            tag => tag.type === 'L1Product'
+        // Events do not come with a "primary tag" fields, so a search for "L1Product" or "ProgrammingLanguage" needs to be done in the standard tags field
+        const eventTags = contentItem.tags.find(
+            tag =>
+                tag.type === 'L1Product' || tag.type === 'ProgrammingLanguage'
         );
 
-        if (eventL1Product) {
-            sideNavFilterSlug = eventL1Product.slug;
+        if (eventTags) {
+            sideNavFilterSlug = eventTags.slug;
         }
     }
 
@@ -71,7 +72,11 @@ export const getContentPageData = async (slug: string[]) => {
 
     crumbs.push(topicContentTypeCrumb);
 
-    let tertiaryNavItems = getSideNav(sideNavFilterSlug, allContentPreval);
+    // In the rare event an event has no tags, set tertiary nav to empty to prevent parent and first child titles both displaying "Events"
+    let tertiaryNavItems =
+        sideNavFilterSlug === '/events'
+            ? []
+            : getSideNav(sideNavFilterSlug, allContentPreval);
     setURLPathForNavItems(tertiaryNavItems);
 
     const metaInfoForTopic = getMetaInfoForTopic(sideNavFilterSlug);

--- a/src/page-templates/content-page/content-page-template.tsx
+++ b/src/page-templates/content-page/content-page-template.tsx
@@ -458,7 +458,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                                 src={getPlaceHolderImage(image?.url)}
                                 sx={{
                                     borderRadius: 'inc30',
-                                    objectFit: 'fill',
+                                    objectFit: 'cover',
                                 }}
                                 layout="fill"
                             />

--- a/src/page-templates/content-page/content-page-template.tsx
+++ b/src/page-templates/content-page/content-page-template.tsx
@@ -458,7 +458,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                                 src={getPlaceHolderImage(image?.url)}
                                 sx={{
                                     borderRadius: 'inc30',
-                                    objectFit: 'cover',
+                                    objectFit: 'fill',
                                 }}
                                 layout="fill"
                             />


### PR DESCRIPTION
## Jira Ticket:

[DEVHUB-1653](https://jira.mongodb.org/browse/DEVHUB-1653)

## Description:
- Fixes duplicate "Event" titles in Tertiary Nav when an Event has no tags (the child title produces a `events/events` slug which leads to a 404)

## Checklist: (Check off where applicable)?
-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added tests that prove my fix is effective or that my feature works