### PR TITLE
[DEVHUB-1645] Match Topic Content Type Events Page Results to Main Events Page

### DIFF
--- a/src/components/event-results/event-results.test.tsx
+++ b/src/components/event-results/event-results.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { SearchProps } from '../../hooks/search/types';
 import { ContentItem } from '../../interfaces/content-item';
 import EventResults from './event-results';
+import { FilterItem } from '@mdb/devcenter-components';
 
 const mockEvent = {
     author: [],
@@ -246,6 +247,49 @@ describe('EventResults', () => {
             screen.getByRole('heading', { name: /all events/i })
         ).toBeInTheDocument();
         expect(screen.getAllByTestId('card-list')).toHaveLength(3); // One event in the search results, both in all results
+    });
+
+    test('When filters are selected, the results and all results are displayed regardless if other criteria are entered', () => {
+        const searchString = 'Event';
+        const locationSelection = 'NYC';
+        const filterItem = {
+            name: 'Virtual',
+            type: 'EventAttendance',
+        } as FilterItem;
+
+        const searchProps = mockSearchPropsFactory({
+            filterProps: {
+                ...searchPropsDefaults.filterProps,
+                filters: [filterItem],
+            },
+            searchStringProps: {
+                ...searchPropsDefaults.searchStringProps,
+                searchString,
+            },
+            locationProps: {
+                ...searchPropsDefaults.locationProps,
+                locationSelection: {
+                    description: locationSelection,
+                },
+            },
+            resultsProps: {
+                ...searchPropsDefaults.resultsProps,
+                allResults: [mockVirtualEvent],
+                unfilteredResults: [mockVirtualEvent],
+                results: [mockVirtualEvent],
+            },
+        });
+        render(
+            <EventResults
+                searchProps={searchProps}
+                searchMetaProps={mockSearchMetaProps}
+            />
+        );
+
+        expect(
+            screen.getByRole('heading', { name: /1 result/i })
+        ).toBeInTheDocument();
+        expect(screen.getAllByTestId('card-list')).toHaveLength(2);
     });
 
     test('Passing gridLayout prop as true changes layout to grid', () => {

--- a/src/components/event-results/event-results.test.tsx
+++ b/src/components/event-results/event-results.test.tsx
@@ -1,0 +1,292 @@
+import { render, screen } from '@testing-library/react';
+import { SearchProps } from '../../hooks/search/types';
+import { ContentItem } from '../../interfaces/content-item';
+import EventResults from './event-results';
+
+const mockEvent = {
+    author: [],
+    category: 'Event',
+    subCategory: 'Industry Event',
+    contentDate: ['2024-04-02T03:30:00.000Z', '2024-04-10T16:00:00.000Z'],
+    description: 'Lorem Ipsum Dolor Sit Amet',
+    slug: '/events/event',
+    tags: [
+        {
+            name: 'Kafka',
+            type: 'Technology',
+            slug: '/technologies/kafka',
+        },
+        {
+            name: 'Industry Event',
+            type: 'EventType',
+            slug: '/events',
+        },
+        {
+            name: 'InPerson',
+            type: 'EventAttendance',
+            slug: '/events',
+        },
+        {
+            name: 'Event',
+            type: 'ContentType',
+            slug: '/events',
+        },
+    ],
+    title: 'Mock InPerson Event',
+    featured: false,
+    location: '20 Rue Quentin-Bauchart Level 2, 75008 Paris, France',
+    coordinates: {
+        lat: 48.8704156,
+        lng: 2.3019408,
+    },
+} as ContentItem;
+
+const mockVirtualEvent = {
+    ...mockEvent,
+    tags: [
+        ...mockEvent.tags.filter(tag => tag.name !== 'InPerson'),
+        {
+            name: 'Virtual',
+            type: 'EventAttendance',
+            slug: '/events',
+        },
+    ],
+    title: 'Mock Virtual Event',
+} as ContentItem;
+
+const searchPropsDefaults = {
+    searchStringProps: { searchString: '', onSearch: () => '' },
+    sortProps: { onSort: () => '' },
+    filterProps: { filters: [], onFilter: () => '' },
+    locationProps: {
+        locationQuery: '',
+        onLocationQuery: () => '',
+        onLocationSelect: () => '',
+        locationValidating: false,
+        geolocationValidating: false,
+        displayOptions: [],
+    },
+    resultsProps: {
+        allResults: [],
+        unfilteredResults: [],
+        results: [],
+        error: '',
+        isValidating: false,
+        searchString: '',
+        filters: [],
+    },
+};
+
+const mockSearchPropsFactory = ({
+    searchStringProps = searchPropsDefaults.searchStringProps,
+    sortProps = searchPropsDefaults.sortProps,
+    filterProps = searchPropsDefaults.filterProps,
+    locationProps = searchPropsDefaults.locationProps,
+    resultsProps = searchPropsDefaults.resultsProps,
+}: {
+    searchStringProps?: SearchProps['searchStringProps'];
+    sortProps?: SearchProps['sortProps'];
+    filterProps?: SearchProps['filterProps'];
+    locationProps?: SearchProps['locationProps'];
+    resultsProps?: SearchProps['resultsProps'];
+}): SearchProps =>
+    ({
+        searchStringProps,
+        sortProps,
+        filterProps,
+        locationProps,
+        resultsProps,
+    } as SearchProps);
+
+const mockSearchMetaProps = {
+    pageTitle: 'MockTitle',
+    metaDescr: 'MockDesc',
+    canonicalUrl: '/events/event',
+    pageNumber: 1,
+    slug: '/events/event',
+    contentType: 'Event',
+    updatePageMeta: () => '',
+};
+
+describe('EventResults', () => {
+    test('All Events render by default', () => {
+        const searchProps = mockSearchPropsFactory({
+            resultsProps: {
+                ...searchPropsDefaults.resultsProps,
+                allResults: [mockEvent],
+                unfilteredResults: [],
+                results: [],
+            },
+        });
+        render(
+            <EventResults
+                searchProps={searchProps}
+                searchMetaProps={mockSearchMetaProps}
+            />
+        );
+
+        expect(
+            screen.getByRole('heading', { name: /all events/i })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('heading', { name: mockEvent.title })
+        ).toBeInTheDocument();
+        expect(screen.getAllByTestId('card-list')).toHaveLength(1);
+    });
+
+    test('When a search string is entered, results and all events are both displayed', () => {
+        const searchString = 'Event';
+
+        const searchProps = mockSearchPropsFactory({
+            searchStringProps: {
+                ...searchPropsDefaults.searchStringProps,
+                searchString,
+            },
+            resultsProps: {
+                ...searchPropsDefaults.resultsProps,
+                allResults: [mockEvent],
+                unfilteredResults: [mockEvent],
+                results: [mockEvent],
+            },
+        });
+
+        render(
+            <EventResults
+                searchProps={searchProps}
+                searchMetaProps={mockSearchMetaProps}
+            />
+        );
+
+        expect(
+            screen.getByRole('heading', {
+                name: new RegExp(`1 result for "${searchString}"`, 'i'),
+            })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('heading', { name: /all events/i })
+        ).toBeInTheDocument();
+        expect(screen.getAllByTestId('card-list')).toHaveLength(2);
+    });
+
+    test('When a location is entered, results and virtual events are both displayed', () => {
+        const locationSelection = 'NYC';
+
+        const searchProps = mockSearchPropsFactory({
+            locationProps: {
+                ...searchPropsDefaults.locationProps,
+                locationSelection: {
+                    description: locationSelection,
+                },
+            },
+            resultsProps: {
+                ...searchPropsDefaults.resultsProps,
+                allResults: [mockEvent, mockVirtualEvent],
+                unfilteredResults: [mockEvent, mockVirtualEvent],
+                results: [mockEvent],
+            },
+        });
+
+        render(
+            <EventResults
+                searchProps={searchProps}
+                searchMetaProps={mockSearchMetaProps}
+            />
+        );
+
+        expect(
+            screen.getByRole('heading', {
+                name: new RegExp(`1 event near "${locationSelection}"`, 'i'),
+            })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('heading', { name: /other virtual events/i })
+        ).toBeInTheDocument();
+        expect(screen.getAllByTestId('card-list')).toHaveLength(2);
+    });
+
+    test('When a location and search string are entered, three results sections are displayed', () => {
+        const searchString = 'Event';
+        const locationSelection = 'NYC';
+
+        const searchProps = mockSearchPropsFactory({
+            searchStringProps: {
+                ...searchPropsDefaults.searchStringProps,
+                searchString,
+            },
+            locationProps: {
+                ...searchPropsDefaults.locationProps,
+                locationSelection: {
+                    description: locationSelection,
+                },
+            },
+            resultsProps: {
+                ...searchPropsDefaults.resultsProps,
+                allResults: [mockEvent, mockVirtualEvent],
+                unfilteredResults: [mockEvent, mockVirtualEvent],
+                results: [mockEvent],
+            },
+        });
+
+        render(
+            <EventResults
+                searchProps={searchProps}
+                searchMetaProps={mockSearchMetaProps}
+            />
+        );
+
+        expect(
+            screen.getByRole('heading', {
+                name: new RegExp(
+                    `1 event for "${searchString}" near ${locationSelection}`,
+                    'i'
+                ),
+            })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('heading', { name: /all events/i })
+        ).toBeInTheDocument();
+        expect(screen.getAllByTestId('card-list')).toHaveLength(3); // One event in the search results, both in all results
+    });
+
+    test('Passing gridLayout prop as true changes layout to grid', () => {
+        const searchProps = mockSearchPropsFactory({
+            resultsProps: {
+                ...searchPropsDefaults.resultsProps,
+                allResults: [mockEvent],
+                unfilteredResults: [],
+                results: [],
+            },
+        });
+        render(
+            <EventResults
+                searchProps={searchProps}
+                searchMetaProps={mockSearchMetaProps}
+                gridLayout
+            />
+        );
+
+        expect(screen.getAllByTestId('card-medium')).toHaveLength(1);
+    });
+
+    test('Passing hideHeader prop as true hides the topmost header properly', () => {
+        const searchProps = mockSearchPropsFactory({
+            resultsProps: {
+                ...searchPropsDefaults.resultsProps,
+                allResults: [mockEvent],
+                unfilteredResults: [],
+                results: [],
+            },
+        });
+        render(
+            <EventResults
+                searchProps={searchProps}
+                searchMetaProps={mockSearchMetaProps}
+                hideHeader
+            />
+        );
+
+        expect(
+            screen.queryByRole('heading', { name: /all events/i })
+        ).not.toBeInTheDocument();
+    });
+});

--- a/src/components/event-results/event-results.tsx
+++ b/src/components/event-results/event-results.tsx
@@ -1,0 +1,226 @@
+import { HorizontalRule, TypographyScale } from '@mdb/flora';
+import { FilterItem, FilterTagSection } from '@mdb/devcenter-components';
+import { useMemo } from 'react';
+import { SearchResults } from '../search';
+import { h5Styles } from '../../styled/layout';
+import { ContentItem } from '../../interfaces/content-item';
+import { SearchMetaProps, SearchProps } from '../../hooks/search/types';
+
+const extraSearchResultsStyles = (showFeatured: boolean) => ({
+    order: showFeatured ? '4' : '3',
+    marginBottom: 'inc30',
+    '> div': {
+        width: '100%',
+    },
+});
+const extraSearchResultsHeadingStyles = (showFeatured: boolean) => ({
+    ...h5Styles,
+    flexGrow: '1',
+    flexBasis: showFeatured ? 'auto' : ['100%', null, 'auto'],
+    order: '2',
+    width: '100%',
+    marginBottom: '0',
+});
+
+interface EventsResultsProps {
+    searchProps: SearchProps;
+    searchMetaProps: SearchMetaProps;
+    hideHeader?: boolean;
+    gridLayout?: boolean;
+}
+
+const EventResults: React.FunctionComponent<EventsResultsProps> = ({
+    searchProps: {
+        searchStringProps: { searchString },
+        filterProps: { onFilter, filters },
+        locationProps: {
+            locationSelection: { description: location = '' } = {},
+        },
+        resultsProps,
+        resultsProps: { isValidating, allResults, unfilteredResults, results },
+    },
+    searchMetaProps,
+    gridLayout = false,
+    hideHeader = false,
+}) => {
+    const showFeatured = !searchString && !filters.length && !location;
+
+    const twoCriteriaResults = results;
+    const showTwoCriteriaResults = location && searchString && !filters.length;
+    const twoCriteriaHeader = `${results.length} event${
+        results.length !== 1 ? 's' : ''
+    } for "${searchString}" near ${location}`;
+    const showTwoCriteriaHeader = !isValidating;
+
+    const otherResultsAnyLocation = useMemo(
+        () =>
+            unfilteredResults.filter(
+                item => !results.some(res => res.slug === item.slug)
+            ),
+        [results, unfilteredResults]
+    );
+    // If there's a search string and a location inputted, display whatever's left of the search query without the location filter underneath
+    // If only one of the search string or location are inputted, then we just display the results
+    const oneCriteriaResults = showTwoCriteriaResults
+        ? otherResultsAnyLocation
+        : results;
+    // Hide if no filtering/querying inputted, or if both search string & location inputted and loading is showing (so we don't show two loaders at once)
+    const showOneCriteriaResults =
+        !(isValidating && showTwoCriteriaResults) && !showFeatured;
+
+    let oneCriteriaHeader = `${oneCriteriaResults.length} `;
+    const plural = oneCriteriaResults.length !== 1 ? 's' : '';
+
+    if (filters.length) {
+        oneCriteriaHeader += `Result${plural}`;
+    } else if (location && searchString) {
+        oneCriteriaHeader += `other result${plural} match${
+            plural ? '' : 'es'
+        } "${searchString}"`;
+    } else if (location) {
+        oneCriteriaHeader += `event${plural} near "${location}"`;
+    } else if (searchString) {
+        oneCriteriaHeader += `Result${plural} for "${searchString}"`;
+    }
+    const showOneCriteriaHeader = !isValidating;
+
+    const showAllOtherResults = !isValidating;
+    // Always want to show all events, except when only a location
+    // is specified where we want to show all virtual events
+    const allOtherResults =
+        location && !searchString
+            ? allResults.filter((res: ContentItem) =>
+                  res.tags.some(
+                      tag =>
+                          tag.type === 'EventAttendance' &&
+                          (tag.name === 'Virtual' || tag.name === 'Hybrid')
+                  )
+              )
+            : allResults;
+
+    return (
+        <>
+            {showTwoCriteriaResults && (
+                <>
+                    <div sx={{ order: '5', width: '100%' }}>
+                        {showTwoCriteriaHeader && (
+                            <TypographyScale
+                                variant="heading2"
+                                sx={extraSearchResultsHeadingStyles(
+                                    showFeatured
+                                )}
+                            >
+                                {twoCriteriaHeader}
+                            </TypographyScale>
+                        )}
+                        {(!!results.length || isValidating) && (
+                            <SearchResults
+                                {...resultsProps}
+                                {...searchMetaProps}
+                                layout={gridLayout ? 'grid' : 'list'}
+                                results={twoCriteriaResults}
+                                extraStyles={extraSearchResultsStyles(
+                                    showFeatured
+                                )}
+                            />
+                        )}
+                    </div>
+                    {!results.length && (
+                        <HorizontalRule sx={{ order: '5', margin: '0' }} />
+                    )}
+                </>
+            )}
+
+            {showOneCriteriaResults && (
+                <>
+                    {/* We only want to display this horizontal rule when search string & location are inputted and "other results" is empty */}
+                    {showTwoCriteriaResults &&
+                        !!twoCriteriaResults.length &&
+                        !oneCriteriaResults.length && (
+                            <HorizontalRule sx={{ order: '5', margin: '0' }} />
+                        )}
+
+                    <div sx={{ order: '5', width: '100%' }}>
+                        {showOneCriteriaHeader && (
+                            <TypographyScale
+                                variant="heading2"
+                                sx={extraSearchResultsHeadingStyles(
+                                    showFeatured
+                                )}
+                            >
+                                {oneCriteriaHeader}
+                            </TypographyScale>
+                        )}
+
+                        {!!filters?.length && (
+                            <div
+                                sx={{
+                                    flexBasis: '100%',
+                                    display: ['none', null, null, 'block'],
+                                    marginTop: 'inc20',
+                                    marginBottom: 'inc40',
+                                }}
+                            >
+                                <FilterTagSection
+                                    allFilters={filters}
+                                    onClearTag={(filterTag: FilterItem) =>
+                                        onFilter(
+                                            filters.filter(
+                                                (item: FilterItem) =>
+                                                    item !== filterTag
+                                            )
+                                        )
+                                    }
+                                    onClearAll={() => onFilter([])}
+                                />
+                            </div>
+                        )}
+
+                        {!!oneCriteriaResults.length && (
+                            <SearchResults
+                                {...resultsProps}
+                                {...searchMetaProps}
+                                layout={gridLayout ? 'grid' : 'list'}
+                                results={oneCriteriaResults}
+                                extraStyles={extraSearchResultsStyles(
+                                    showFeatured
+                                )}
+                            />
+                        )}
+                    </div>
+                    {!oneCriteriaResults.length && (
+                        <HorizontalRule sx={{ order: '5', margin: '0' }} />
+                    )}
+                </>
+            )}
+
+            {showAllOtherResults && (
+                <div sx={{ order: '6', width: '100%' }}>
+                    <TypographyScale
+                        variant="heading2"
+                        sx={extraSearchResultsHeadingStyles(showFeatured)}
+                    >
+                        {location && !searchString
+                            ? 'Other Virtual Events'
+                            : hideHeader && !searchString
+                            ? ''
+                            : 'All Events'}
+                    </TypographyScale>
+
+                    <SearchResults
+                        {...resultsProps}
+                        {...searchMetaProps}
+                        layout={gridLayout ? 'grid' : 'list'}
+                        results={allOtherResults}
+                        isValidating={
+                            allResults.length === 0 ? isValidating : false
+                        }
+                        extraStyles={extraSearchResultsStyles(showFeatured)}
+                    />
+                </div>
+            )}
+        </>
+    );
+};
+
+export default EventResults;

--- a/src/components/event-results/index.ts
+++ b/src/components/event-results/index.ts
@@ -1,0 +1,3 @@
+import EventResults from './event-results';
+
+export default EventResults;

--- a/src/hooks/search/meta.ts
+++ b/src/hooks/search/meta.ts
@@ -8,9 +8,12 @@ import { replaceHistoryState } from './utils';
 export const useSearchMeta = (
     pageNumber: number,
     slug: string,
-    title: string,
-    customBuildPageTitle?: (pageNumber: number) => string
+    contentType: string,
+    customBuildPageTitle?: (pageNumber: number) => string,
+    titleOverride?: string
 ): SearchMetaProps => {
+    const title = titleOverride || contentType;
+
     const { asPath, route } = useRouter();
     const { publicRuntimeConfig } = getConfig();
     const { absoluteBasePath } = publicRuntimeConfig;
@@ -75,5 +78,13 @@ export const useSearchMeta = (
         [buildPageTitle, defaultMetaDescr, slug, absoluteBasePath, asPath]
     );
 
-    return { pageTitle, metaDescr, canonicalUrl, updatePageMeta };
+    return {
+        pageTitle,
+        metaDescr,
+        canonicalUrl,
+        updatePageMeta,
+        pageNumber,
+        slug,
+        contentType,
+    };
 };

--- a/src/hooks/search/types.ts
+++ b/src/hooks/search/types.ts
@@ -54,5 +54,8 @@ export interface SearchMetaProps {
     pageTitle: string;
     metaDescr: string;
     canonicalUrl: string;
+    pageNumber: number;
+    slug: string;
+    contentType: string;
     updatePageMeta: (pageNumber?: number) => void;
 }

--- a/src/page-templates/content-type-page/content-type-body.tsx
+++ b/src/page-templates/content-type-page/content-type-body.tsx
@@ -39,7 +39,7 @@ const ContentTypeBody: React.FunctionComponent<
         resultsProps: { results, isValidating },
         clearSearchParam,
     },
-    searchMetaProps: { updatePageMeta },
+    searchMetaProps,
     featured,
     extraFeatured: {
         featuredLanguages,
@@ -50,8 +50,6 @@ const ContentTypeBody: React.FunctionComponent<
     mobileFiltersOpen,
     setMobileFiltersOpen,
     contentType,
-    pageNumber,
-    slug,
     children,
 }) => {
     const showFeatured = !searchString && !filters.length;
@@ -202,10 +200,7 @@ const ContentTypeBody: React.FunctionComponent<
 
                 <SearchResults
                     {...resultsProps}
-                    pageNumber={pageNumber}
-                    slug={slug}
-                    updatePageMeta={updatePageMeta}
-                    contentType={contentType}
+                    {...searchMetaProps}
                     extraStyles={{
                         order: showFeatured ? '4' : '3',
                     }}

--- a/src/page-templates/content-type-page/content-type-template.tsx
+++ b/src/page-templates/content-type-page/content-type-template.tsx
@@ -53,6 +53,8 @@ const ContentTypePage: React.FunctionComponent<
     const searchMetaProps = useSearchMeta(
         pageNumber,
         slug,
+        contentType,
+        undefined,
         pluralize(contentType)
     );
     const { pageTitle, metaDescr, updatePageMeta, canonicalUrl } =

--- a/src/page-templates/topic-content-type-page/topic-content-type-page-template.tsx
+++ b/src/page-templates/topic-content-type-page/topic-content-type-page-template.tsx
@@ -45,6 +45,7 @@ import { useRequestContentModal } from '../../contexts/request-content-modal';
 import { Tag } from '../../interfaces/tag';
 import { tagToTopic } from '../../utils/tag-to-topic';
 import { LocationOptions } from '../../hooks/search/types';
+import EventResults from '../../components/event-results';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pluralize = require('pluralize');
@@ -68,7 +69,7 @@ const spanAllColumns = {
 };
 
 const extraSearchBoxStyles = {
-    marginBottom: ['0', null, 'inc50'],
+    marginBottom: '0',
 };
 const extraSortBoxStyles = {
     display: 'block',
@@ -163,21 +164,28 @@ const TopicContentTypePageTemplate: NextPage<TopicContentTypePageProps> = ({
 
     const { setModalStage } = useRequestContentModal();
 
+    const searchMetaProps = useSearchMeta(
+        pageNumber,
+        topicSlug + contentTypeSlug,
+        contentType,
+        buildPageTitle(contentType, topicName)
+    );
     const { pageTitle, metaDescr, canonicalUrl, updatePageMeta } =
-        useSearchMeta(
-            pageNumber,
-            topicSlug + contentTypeSlug,
-            contentType,
-            buildPageTitle(contentType, topicName)
-        );
+        searchMetaProps;
 
+    const searchProps = useSearch(
+        initialSearchContent,
+        updatePageMeta,
+        contentType,
+        topicSlug
+    );
     const {
         searchStringProps,
         sortProps,
         filterProps,
         resultsProps,
         locationProps,
-    } = useSearch(initialSearchContent, updatePageMeta, contentType, topicSlug);
+    } = searchProps;
 
     const mainGridDesktopRowsCount = subTopics.length > 0 ? 4 : 3;
 
@@ -291,7 +299,17 @@ const TopicContentTypePageTemplate: NextPage<TopicContentTypePageProps> = ({
                         />
                     )}
 
-                    <div sx={extraSearchWrapperStyles}>
+                    <div
+                        sx={{
+                            ...extraSearchWrapperStyles,
+                            ...(contentType === 'Event'
+                                ? {
+                                      rowGap: ['inc40', null, 'inc70'],
+                                      columnGap: 'inc40',
+                                  }
+                                : {}),
+                        }}
+                    >
                         <div sx={titleStyles}>
                             <TypographyScale
                                 variant="heading5"
@@ -318,34 +336,44 @@ const TopicContentTypePageTemplate: NextPage<TopicContentTypePageProps> = ({
                         />
 
                         {contentType === 'Event' && (
-                            <LocationBox
-                                {...locationProps}
-                                displayOptions={locationDisplayOptions}
-                            />
+                            <>
+                                <LocationBox
+                                    {...locationProps}
+                                    displayOptions={locationDisplayOptions}
+                                />
+
+                                <EventResults
+                                    searchProps={searchProps}
+                                    searchMetaProps={searchMetaProps}
+                                    hideHeader
+                                    gridLayout
+                                />
+                            </>
                         )}
 
                         {contentType !== 'Event' && (
-                            <SortBox
-                                {...sortProps}
-                                extraStyles={extraSortBoxStyles}
-                            />
-                        )}
+                            <>
+                                <SortBox
+                                    {...sortProps}
+                                    extraStyles={extraSortBoxStyles}
+                                />
 
-                        {contentType === 'Code Example' && (
-                            <ExtraCodeExampleCheckboxes {...filterProps} />
-                        )}
+                                {contentType === 'Code Example' && (
+                                    <ExtraCodeExampleCheckboxes
+                                        {...filterProps}
+                                    />
+                                )}
 
-                        <SearchResults
-                            {...resultsProps}
-                            pageNumber={pageNumber}
-                            slug={topicSlug + contentTypeSlug}
-                            updatePageMeta={updatePageMeta}
-                            contentType={contentType}
-                            layout="grid"
-                            extraStyles={{
-                                marginTop: ['inc30', null, 0],
-                            }}
-                        />
+                                <SearchResults
+                                    {...resultsProps}
+                                    {...searchMetaProps}
+                                    layout="grid"
+                                    extraStyles={{
+                                        marginTop: 'inc30',
+                                    }}
+                                />
+                            </>
+                        )}
                     </div>
                 </GridLayout>
             </div>

--- a/src/page-templates/topic-page/topic-page-template.tsx
+++ b/src/page-templates/topic-page/topic-page-template.tsx
@@ -117,13 +117,14 @@ const TopicPageTemplate: NextPage<TopicPageProps> = ({
         );
     });
 
+    const searchMetaProps = useSearchMeta(
+        pageNumber,
+        slug,
+        contentType,
+        buildPageTitle(contentType, name)
+    );
     const { pageTitle, metaDescr, canonicalUrl, updatePageMeta } =
-        useSearchMeta(
-            pageNumber,
-            slug,
-            contentType,
-            buildPageTitle(contentType, name)
-        );
+        searchMetaProps;
 
     const { searchStringProps, sortProps, resultsProps } = useSearch(
         initialSearchContent,
@@ -249,10 +250,7 @@ const TopicPageTemplate: NextPage<TopicPageProps> = ({
 
                         <SearchResults
                             {...resultsProps}
-                            pageNumber={pageNumber}
-                            slug={slug}
-                            updatePageMeta={updatePageMeta}
-                            contentType={contentType}
+                            {...searchMetaProps}
                             extraStyles={{
                                 marginTop: ['inc30', null, 0],
                             }}

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -10,39 +10,17 @@ import { ContentTypePageProps } from '../page-templates/content-type-page/types'
 import { getContentTypePageData } from '../page-templates/content-type-page/content-type-data';
 import { parsePageNumber } from '../utils/page-type-factory';
 import { isValidPage } from '../components/search/utils';
-import { LocationBox, SearchBox, SearchResults } from '../components/search';
+import { LocationBox, SearchBox } from '../components/search';
 import { searchWrapperStyles } from '../components/search/styles';
-import {
-    Button,
-    ESystemIconNames,
-    GridLayout,
-    HorizontalRule,
-    TypographyScale,
-} from '@mdb/flora';
-import { h5Styles } from '../styled/layout';
-import { FilterItem, FilterTagSection } from '@mdb/devcenter-components';
+import { Button, ESystemIconNames, GridLayout } from '@mdb/flora';
+import { FilterItem } from '@mdb/devcenter-components';
 import { useCallback } from 'react';
 import { FeaturedCardSection } from '../components/card-section';
 import { DesktopFilters, MobileFilters } from '../components/search-filters';
 import { desktopFiltersStyles } from '../page-templates/content-type-page/styles';
 import { SearchMetaProps, SearchProps } from '../hooks/search/types';
-import { ContentItem } from '../interfaces/content-item';
+import EventResults from '../components/event-results';
 
-const extraSearchResultsStyles = (showFeatured: boolean) => ({
-    order: showFeatured ? '4' : '3',
-    marginBottom: 'inc70',
-    '> div': {
-        width: '100%',
-    },
-});
-const extraSearchResultsHeadingStyles = (showFeatured: boolean) => ({
-    ...h5Styles,
-    flexGrow: '1',
-    flexBasis: showFeatured ? 'auto' : ['100%', null, 'auto'],
-    order: '2',
-    width: '100%',
-    marginBottom: '0',
-});
 interface EventsPageComponentProps {
     searchProps: SearchProps;
     searchMetaProps: SearchMetaProps;
@@ -61,12 +39,11 @@ const fixInPersonFilter = (filters: FilterItem[], hyphenate = true) =>
 const EventsPageComponent: React.FunctionComponent<
     EventsPageComponentProps & ContentTypePageProps
 > = ({
+    searchProps,
     searchProps: {
         searchStringProps,
         searchStringProps: { searchString },
         filterProps,
-        resultsProps,
-        resultsProps: { isValidating, allResults, unfilteredResults, results },
         locationProps,
         locationProps: {
             locationSelection: { description: location = '' } = {},
@@ -74,15 +51,12 @@ const EventsPageComponent: React.FunctionComponent<
         },
         clearSearchParam,
     },
-    searchMetaProps: { updatePageMeta },
+    searchMetaProps,
     mobileFiltersOpen,
     setMobileFiltersOpen,
     featured,
-    pageNumber,
     children,
     filterItems: rawFilterItems,
-    slug,
-    contentType,
 }) => {
     // TODO: Refactor and remove the following three consts
     const filters = useMemo(
@@ -104,57 +78,6 @@ const EventsPageComponent: React.FunctionComponent<
     );
 
     const showFeatured = !searchString && !filters.length && !location;
-
-    const twoCriteriaResults = results;
-    const showTwoCriteriaResults = location && searchString && !filters.length;
-    const twoCriteriaHeader = `${results.length} event${
-        results.length !== 1 ? 's' : ''
-    } for "${searchString}" near ${location}`;
-
-    const otherResultsAnyLocation = useMemo(
-        () =>
-            unfilteredResults.filter(
-                item => !results.some(res => res.slug === item.slug)
-            ),
-        [results, unfilteredResults]
-    );
-    // If there's a search string and a location inputted, display whatever's left of the search query without the location filter underneath
-    // If only one of the search string or location are inputted, then we just display the results
-    const oneCriteriaResults = showTwoCriteriaResults
-        ? otherResultsAnyLocation
-        : results;
-    // Hide if no filtering/querying inputted, or if both search string & location inputted and loading is showing (so we don't show two loaders at once)
-    const showOneCriteriaResults =
-        !(isValidating && showTwoCriteriaResults) && !showFeatured;
-
-    let oneCriteriaHeader = `${oneCriteriaResults.length} `;
-    const plural = oneCriteriaResults.length !== 1 ? 's' : '';
-
-    if (filters.length) {
-        oneCriteriaHeader += `Result${plural}`;
-    } else if (location && searchString) {
-        oneCriteriaHeader += `other result${plural} match${
-            plural ? '' : 'es'
-        } "${searchString}"`;
-    } else if (location) {
-        oneCriteriaHeader += `event${plural} near "${location}"`;
-    } else if (searchString) {
-        oneCriteriaHeader += `Result${plural} for "${searchString}"`;
-    }
-
-    const showAllOtherResults = !isValidating;
-    // Always want to show all events, except when only a location
-    // is specified where we want to show all virtual events
-    const allOtherResults =
-        location && !searchString
-            ? allResults.filter((res: ContentItem) =>
-                  res.tags.some(
-                      tag =>
-                          tag.type === 'EventAttendance' &&
-                          (tag.name === 'Virtual' || tag.name === 'Hybrid')
-                  )
-              )
-            : allResults;
 
     const locationSelect = useCallback(
         (selection: string) => {
@@ -269,129 +192,10 @@ const EventsPageComponent: React.FunctionComponent<
                     {!!filters.length && ` (${filters.length})`}
                 </Button>
 
-                {showTwoCriteriaResults && (
-                    <>
-                        <div sx={{ order: '5', width: '100%' }}>
-                            {!isValidating && (
-                                <TypographyScale
-                                    variant="heading2"
-                                    sx={extraSearchResultsHeadingStyles(
-                                        showFeatured
-                                    )}
-                                >
-                                    {twoCriteriaHeader}
-                                </TypographyScale>
-                            )}
-                            {!!results.length && (
-                                <SearchResults
-                                    {...resultsProps}
-                                    results={twoCriteriaResults}
-                                    pageNumber={pageNumber}
-                                    updatePageMeta={updatePageMeta}
-                                    extraStyles={extraSearchResultsStyles(
-                                        showFeatured
-                                    )}
-                                    slug={slug}
-                                    contentType={contentType}
-                                />
-                            )}
-                        </div>
-                        {!results.length && (
-                            <HorizontalRule sx={{ order: '5' }} />
-                        )}
-                    </>
-                )}
-
-                {showOneCriteriaResults && (
-                    <>
-                        {/* We only want to display this horizontal rule when search string & location are inputted and "other results" is empty */}
-                        {showTwoCriteriaResults &&
-                            !!twoCriteriaResults.length &&
-                            !oneCriteriaResults.length && (
-                                <HorizontalRule sx={{ order: '5' }} />
-                            )}
-
-                        <div sx={{ order: '5', width: '100%' }}>
-                            {!isValidating && (
-                                <TypographyScale
-                                    variant="heading2"
-                                    sx={extraSearchResultsHeadingStyles(
-                                        showFeatured
-                                    )}
-                                >
-                                    {oneCriteriaHeader}
-                                </TypographyScale>
-                            )}
-
-                            {!!filters?.length && (
-                                <div
-                                    sx={{
-                                        flexBasis: '100%',
-                                        display: ['none', null, null, 'block'],
-                                        marginTop: 'inc20',
-                                        marginBottom: 'inc40',
-                                    }}
-                                >
-                                    <FilterTagSection
-                                        allFilters={filters}
-                                        onClearTag={(filterTag: FilterItem) =>
-                                            onFilter(
-                                                filters.filter(
-                                                    (item: FilterItem) =>
-                                                        item !== filterTag
-                                                )
-                                            )
-                                        }
-                                        onClearAll={() => onFilter([])}
-                                    />
-                                </div>
-                            )}
-
-                            {!!oneCriteriaResults.length && (
-                                <SearchResults
-                                    {...resultsProps}
-                                    results={oneCriteriaResults}
-                                    pageNumber={pageNumber}
-                                    updatePageMeta={updatePageMeta}
-                                    extraStyles={extraSearchResultsStyles(
-                                        showFeatured
-                                    )}
-                                    slug={slug}
-                                    contentType={contentType}
-                                />
-                            )}
-                        </div>
-                        {!oneCriteriaResults.length && (
-                            <HorizontalRule sx={{ order: '5' }} />
-                        )}
-                    </>
-                )}
-
-                {showAllOtherResults && (
-                    <div sx={{ order: '6', width: '100%' }}>
-                        <TypographyScale
-                            variant="heading2"
-                            sx={extraSearchResultsHeadingStyles(showFeatured)}
-                        >
-                            {location && !searchString
-                                ? 'Other Virtual Events'
-                                : 'All Events'}
-                        </TypographyScale>
-
-                        <SearchResults
-                            {...resultsProps}
-                            results={allOtherResults}
-                            isValidating={
-                                allResults.length === 0 ? isValidating : false
-                            }
-                            pageNumber={pageNumber}
-                            updatePageMeta={updatePageMeta}
-                            extraStyles={extraSearchResultsStyles(showFeatured)}
-                            slug={slug}
-                            contentType={contentType}
-                        />
-                    </div>
-                )}
+                <EventResults
+                    searchProps={searchProps}
+                    searchMetaProps={searchMetaProps}
+                />
 
                 {children}
             </div>

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -47,11 +47,14 @@ const Search: NextPage<SearchProps> = ({
     const router = useRouter();
     const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
-    const { pageTitle, updatePageMeta, canonicalUrl } = useSearchMeta(
+    const searchMetaProps = useSearchMeta(
         pageNumber,
         '/search',
+        'Content',
+        undefined,
         'Search'
     );
+    const { pageTitle, updatePageMeta, canonicalUrl } = searchMetaProps;
 
     const {
         searchStringProps,
@@ -171,10 +174,8 @@ const Search: NextPage<SearchProps> = ({
 
                         <SearchResults
                             {...resultsProps}
-                            pageNumber={pageNumber}
+                            {...searchMetaProps}
                             slug="/search"
-                            updatePageMeta={updatePageMeta}
-                            contentType="Content"
                             noResultsFooter={
                                 <Button
                                     hasIcon={true}


### PR DESCRIPTION
## Jira Ticket:

[DEVHUB-1645](https://jira.mongodb.org/browse/DEVHUB-1645)

## Description:

- Extract the events page's multi-tiered results to its own component
- Add tests for new component
- Consume the new component in the events page and also in the topic content type page
- During this work, I noticed I was doing a lot of passing around search-meta-related props unnecessarily, so I added them to the `useSearchMeta` hook to cut down on prop passing

## Related Issue(s) or Dependencies (if applicable):

Please link to the issue(s) or dependencies here

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![Screen Shot 2023-01-19 at 2 40 13 PM](https://user-images.githubusercontent.com/110849018/213544077-fc7d8aef-c64f-4e6d-8f7b-a51b7d335d71.png)

