### PR TITLE
[DEVHUB-1662]: The "When" field doesn't need times when it's a multi-day event

### DIFF
--- a/src/components/event-widget/event-widget.test.tsx
+++ b/src/components/event-widget/event-widget.test.tsx
@@ -20,15 +20,8 @@ describe('[Component]: Event Widget', () => {
             />
         );
 
-        /*
-            Only test for date formatting because of .toLocaleString() usage
-            Exact match would cause wacky behavior of times when running tests locally vs. during build
-        */
         expect(
-            screen.getByText('November 30, 2022', { exact: false })
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText('December 1, 2022', { exact: false })
+            screen.getByText('Nov 30, 2022 - Dec 1, 2022 EST')
         ).toBeInTheDocument();
 
         // sets location

--- a/src/components/event-widget/event-widget.test.tsx
+++ b/src/components/event-widget/event-widget.test.tsx
@@ -20,8 +20,12 @@ describe('[Component]: Event Widget', () => {
             />
         );
 
+        /*
+            Only test for date formatting because of .toLocaleString() usage
+            Exact match would cause wacky behavior of times when running tests locally vs. during build
+        */
         expect(
-            screen.getByText('Nov 30, 2022 - Dec 1, 2022 EST')
+            screen.getByText('Nov 30, 2022 - Dec 1, 2022', { exact: false })
         ).toBeInTheDocument();
 
         // sets location

--- a/src/components/event-widget/event-widget.tsx
+++ b/src/components/event-widget/event-widget.tsx
@@ -7,7 +7,7 @@ import {
 } from '@mdb/flora';
 import { ThemeUICSSObject } from 'theme-ui';
 
-import { formatSingleDate } from '../../utils/format-date';
+import { formatDateRange } from '../../utils/format-date';
 
 import styles from './styles';
 
@@ -30,9 +30,6 @@ export default function EventWidget({
     registrationLink = '',
     virtualLinkText = 'Virtual Link',
 }: EventWidgetProps) {
-    const startTime = dates[0] ? formatSingleDate(dates[0]) : '';
-    const endTime = dates[1] ? `- ${formatSingleDate(dates[1])}` : '';
-
     return (
         <div sx={{ ...wrapperStyles }}>
             <div sx={styles.widget}>
@@ -43,7 +40,7 @@ export default function EventWidget({
                     </TypographyScale>
                 </div>
                 <TypographyScale variant="body3" sx={styles.content}>
-                    {startTime} {endTime}
+                    {formatDateRange(dates[0], dates[1])}
                 </TypographyScale>
             </div>
             {(location || virtualLink) && (

--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -80,11 +80,12 @@ export const formatDateRange = (start: string, end: string) => {
                 month: 'short',
                 day: 'numeric',
             }) + ' | ';
-        output += startDate.toLocaleString('default', {
-            hour: 'numeric',
-            minute: 'numeric',
-            hour12: true,
-        });
+        output +=
+            startDate.toLocaleString('default', {
+                hour: 'numeric',
+                minute: 'numeric',
+                hour12: true,
+            }) + ` ${timeZone}`;
     } else if (dateCompare(startDate, endDate)) {
         // Same day different time, format as a time range
         output +=
@@ -93,18 +94,18 @@ export const formatDateRange = (start: string, end: string) => {
                 month: 'short',
                 day: 'numeric',
             }) + ' | ';
-
         output +=
             startDate.toLocaleString('default', {
                 hour: 'numeric',
                 minute: 'numeric',
                 hour12: true,
             }) + ' - ';
-        output += endDate.toLocaleString('default', {
-            hour: 'numeric',
-            minute: 'numeric',
-            hour12: true,
-        });
+        output +=
+            endDate.toLocaleString('default', {
+                hour: 'numeric',
+                minute: 'numeric',
+                hour12: true,
+            }) + ` ${timeZone}`;
     } else {
         // Different days, format as a date range
         output +=
@@ -120,7 +121,7 @@ export const formatDateRange = (start: string, end: string) => {
         });
     }
 
-    return `${output} ${timeZone}`;
+    return output;
 };
 
 export const getLatestDate = (contentDate: string, updatedDate?: string) => {

--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -113,22 +113,10 @@ export const formatDateRange = (start: string, end: string) => {
                 month: 'short',
                 day: 'numeric',
             }) + ' - ';
-        output +=
-            startDate.toLocaleString('default', {
-                hour: 'numeric',
-                minute: 'numeric',
-                hour12: true,
-            }) + ' | ';
-        output +=
-            endDate.toLocaleString('default', {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-            }) + ' - ';
         output += endDate.toLocaleString('default', {
-            hour: 'numeric',
-            minute: 'numeric',
-            hour12: true,
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
         });
     }
 
@@ -149,19 +137,4 @@ export const getLatestDate = (contentDate: string, updatedDate?: string) => {
     }
 
     return latestDate;
-};
-
-// Example of return format: December 13, 2022 12:00 PM
-export const formatSingleDate = (date: string) => {
-    const dateObj = new Date(date);
-
-    return `${dateObj.toLocaleDateString('default', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-    })} ${dateObj.toLocaleTimeString('default', {
-        hour: 'numeric',
-        minute: 'numeric',
-        hour12: true,
-    })}`;
 };


### PR DESCRIPTION
## Jira Ticket:

[DEVHUB-1662](https://jira.mongodb.org/browse/DEVHUB-1662)

## Description:

Formats Event Dates based on UAT feedback

## Screenshots (if appropriate):

On Events Page:
<img width="1174" alt="Screen Shot 2023-01-24 at 4 50 03 PM" src="https://user-images.githubusercontent.com/20843509/214428785-3ead3e98-0c10-455c-8812-9caf6df43976.png">

<img width="1121" alt="Screen Shot 2023-01-24 at 4 50 21 PM" src="https://user-images.githubusercontent.com/20843509/214428839-64567b04-a424-4ad5-ab17-53b0b053395e.png">


On Detail Page:
<img width="356" alt="Screen Shot 2023-01-24 at 4 50 57 PM" src="https://user-images.githubusercontent.com/20843509/214428940-f3a319c2-43bd-496d-864c-382a8953d327.png">

<img width="385" alt="Screen Shot 2023-01-24 at 4 51 27 PM" src="https://user-images.githubusercontent.com/20843509/214429095-327bda27-7036-48bf-8791-5c87b10001aa.png">

