### PR TITLE
Fix Events Results not showing when JavaScript is disabled

### DIFF
--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -33,6 +33,7 @@ import { getURLPath } from '../../utils/format-url-path';
 import { h5Styles, h6Styles } from '../../styled/layout';
 import EventIcon from '../icons/event-icon';
 import { PillCategory } from '../../types/pill-category';
+import isServerSide from '../../utils/is-server-side';
 
 const CardThumbnail = ({
     thumbnail: { url = '', alt = '', city = '' } = {},
@@ -126,11 +127,10 @@ const Card: React.FunctionComponent<CardProps> = ({
     const truncatedDescription =
         description && parse(description ? description : '');
 
-    const isExternalLink =
-        typeof window === 'undefined'
-            ? false
-            : new URL(document.baseURI).origin !==
-              new URL(slug, document.baseURI).origin;
+    const isExternalLink = isServerSide()
+        ? false
+        : new URL(document.baseURI).origin !==
+          new URL(slug, document.baseURI).origin;
 
     return (
         <div

--- a/src/components/icons/event-icon/event-icon.tsx
+++ b/src/components/icons/event-icon/event-icon.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { thumbnailStyles } from '../../card/styles';
+import isServerSide from '../../../utils/is-server-side';
 
 const PILL_PADDING = 13;
 const RIGHT_MARGIN = 16;
@@ -383,7 +384,7 @@ const EventIcon = ({ text }: { text?: string }) => {
                     d="M151.294 110.103C151.22 110.068 151.19 109.98 151.225 109.906L153.574 105.046C153.609 104.973 153.697 104.942 153.77 104.978L158.618 107.332C158.691 107.368 158.722 107.456 158.686 107.529L156.338 112.39C156.302 112.463 156.214 112.494 156.141 112.458L151.294 110.103ZM151.554 109.902L156.137 112.128L158.357 107.534L153.774 105.307L151.554 109.902Z"
                     fill="black"
                 />
-                {text && (
+                {text && !isServerSide() && (
                     <g>
                         <rect
                             x={rectX}

--- a/src/components/search/results.tsx
+++ b/src/components/search/results.tsx
@@ -102,24 +102,21 @@ const SearchResults: React.FunctionComponent<ResultsProps> = ({
                                         data-testid="search-results"
                                         sx={dataStyles(layout)}
                                     >
-                                        {resultsToShow.map(item => {
-                                            console.log(item);
-                                            return (
-                                                <Card
-                                                    key={item.slug}
-                                                    sx={extraCardStyles}
-                                                    hideTagsOnMobile={
-                                                        layout === 'list'
-                                                    }
-                                                    {...getCardProps(
-                                                        item,
-                                                        layout === 'list'
-                                                            ? 'list'
-                                                            : 'medium'
-                                                    )}
-                                                />
-                                            );
-                                        })}
+                                        {resultsToShow.map(item => (
+                                            <Card
+                                                key={item.slug}
+                                                sx={extraCardStyles}
+                                                hideTagsOnMobile={
+                                                    layout === 'list'
+                                                }
+                                                {...getCardProps(
+                                                    item,
+                                                    layout === 'list'
+                                                        ? 'list'
+                                                        : 'medium'
+                                                )}
+                                            />
+                                        ))}
                                     </div>
 
                                     {showLoadMoreButton && (

--- a/src/components/search/results.tsx
+++ b/src/components/search/results.tsx
@@ -102,21 +102,24 @@ const SearchResults: React.FunctionComponent<ResultsProps> = ({
                                         data-testid="search-results"
                                         sx={dataStyles(layout)}
                                     >
-                                        {resultsToShow.map(item => (
-                                            <Card
-                                                key={item.slug}
-                                                sx={extraCardStyles}
-                                                hideTagsOnMobile={
-                                                    layout === 'list'
-                                                }
-                                                {...getCardProps(
-                                                    item,
-                                                    layout === 'list'
-                                                        ? 'list'
-                                                        : 'medium'
-                                                )}
-                                            />
-                                        ))}
+                                        {resultsToShow.map(item => {
+                                            console.log(item);
+                                            return (
+                                                <Card
+                                                    key={item.slug}
+                                                    sx={extraCardStyles}
+                                                    hideTagsOnMobile={
+                                                        layout === 'list'
+                                                    }
+                                                    {...getCardProps(
+                                                        item,
+                                                        layout === 'list'
+                                                            ? 'list'
+                                                            : 'medium'
+                                                    )}
+                                                />
+                                            );
+                                        })}
                                     </div>
 
                                     {showLoadMoreButton && (

--- a/src/utils/is-server-side.ts
+++ b/src/utils/is-server-side.ts
@@ -1,0 +1,3 @@
+const isServerSide = () => typeof window === 'undefined';
+
+export default isServerSide;


### PR DESCRIPTION
For SEO reasons, results should be generated statically in the build output, as well as dynamically, which can be verified by disabling javascript. Previously, doing so resulted in a "No Results" screen on the Events page, but this PR should fix that issue. I also created a utility function `isServerSide()` instead of checking `typeof window === 'undefined'` every time.