### PR TITLE
[DEVHUB-1671]: Twitter Preview Card Not visible 

### DIFF
--- a/src/page-templates/content-page/content-page-template.tsx
+++ b/src/page-templates/content-page/content-page-template.tsx
@@ -597,6 +597,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                 twitter={{
                     site: seo?.twitter_site,
                     handle: seo?.twitter_creator,
+                    cardType: seo?.twitter_card,
                 }}
                 openGraph={{
                     url: seo?.og_url,


### PR DESCRIPTION
## Jira Ticket:

Link to jira ticket [DEVHUB-1671](https://jira.mongodb.org/browse/DEVHUB-1671)

## Description:

Looks like `cardType` prop was missing from `twitter` in `<NextSEO />`. Need to test out on staging for 100% confirmation