### PR TITLE
[DEVHUB-1681] Add new sort order for events.

### DIFF
--- a/src/components/search/types.ts
+++ b/src/components/search/types.ts
@@ -79,6 +79,6 @@ export interface SearchItem {
 }
 
 // add back when Most Popular is implemented
-// export type SortByType = 'Newest' | 'Most Popular' | 'Highest Rated';
-export type SortByType = 'Newest' | 'Highest Rated';
+// export type SortByType = 'Newest' | 'Most Popular' | 'Highest Rated' | 'Closest Upcoming';
+export type SortByType = 'Newest' | 'Highest Rated' | 'Closest Upcoming';
 export const defaultSortByType: SortByType = 'Newest';

--- a/src/components/search/utils.ts
+++ b/src/components/search/utils.ts
@@ -7,6 +7,7 @@ export const sortByOptions: { [key in SortByType]: number } = {
     Newest: 0,
     // 'Most Popular': 1, // add back when Most Popular is implemented
     'Highest Rated': 2,
+    'Closest Upcoming': 3,
 };
 
 export interface SearchQueryParams {

--- a/src/page-templates/content-type-page/content-type-data.ts
+++ b/src/page-templates/content-type-page/content-type-data.ts
@@ -23,7 +23,10 @@ export const getContentTypePageData = async (
         initialSearchContent = await getSearchContent({
             searchString: '',
             contentType: contentType,
-            sortBy: defaultSortByType,
+            sortBy:
+                contentType === 'Event'
+                    ? 'Closest Upcoming'
+                    : defaultSortByType,
         });
     } catch (e) {
         Sentry.captureException(e);


### PR DESCRIPTION
## Jira Ticket:

[DEVHUB-1681](https://jira.mongodb.org/browse/DEVHUB-1681)

## Description:

Already added a new sort order in the Realm search function. After talking with Mike, there's no real use case for that "nearest to the current date" logic, so this new sort mode is just the inverse of "Newest".
