### PR TITLE
[DEVHUB-1606] Fix backend compatibility, fix follow-link functionality.

### DIFF
--- a/environments/prod.yaml
+++ b/environments/prod.yaml
@@ -30,7 +30,6 @@ envSecrets:
   STRAPI_API_TOKEN: devcenter-secrets
   GOOGLE_PLACES_API_KEY: devcenter-secrets
   REALM_API_KEY: devcenter-secrets
-  PERSONALIZATION_URL: devcenter-secrets
 
 autoscaling:
   minReplicas: 4

--- a/environments/staging.yaml
+++ b/environments/staging.yaml
@@ -28,7 +28,6 @@ envSecrets:
   STRAPI_API_TOKEN: devcenter-secrets
   GOOGLE_PLACES_API_KEY: devcenter-secrets
   REALM_API_KEY: devcenter-secrets
-  PERSONALIZATION_URL: devcenter-secrets
 
 autoscaling:
   minReplicas: 2

--- a/src/components/modal/personalization/utils.ts
+++ b/src/components/modal/personalization/utils.ts
@@ -2,6 +2,7 @@ import { Tag } from '../../../interfaces/tag';
 import { MetaInfo } from '../../../interfaces/meta-info';
 import { PersonalizationModalConfig } from './types';
 import { getURLPath } from '../../../utils/format-url-path';
+import refreshSession from '../../../utils/refresh-session';
 
 export function initializePersonalizationConfig(metaInfo: MetaInfo[]) {
     const languages: PersonalizationModalConfig = {
@@ -45,7 +46,7 @@ export async function submitPersonalizationSelections({
                 body: JSON.stringify({ followedTags, emailPreference }),
             }
         );
-
+        refreshSession();
         const res = await req.json();
         return res; // there's no current plan to display success/failure to user
     } catch {

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -6,14 +6,12 @@ import * as Sentry from '@sentry/nextjs';
 import { User } from '../../../interfaces/user-preference';
 
 async function getUser(userId: string | unknown): Promise<any> {
-    const url = `${process.env.PERSONALIZATION_URL}/user_preferences?userId=${userId}`;
-    const apiKey = process.env.REALM_API_KEY || '';
+    const url = `${process.env.BACKEND_URL}/api/user_preferences/${userId}`;
     const options = {
         method: 'GET',
         headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            apiKey: apiKey,
         },
     };
     try {
@@ -26,16 +24,12 @@ async function getUser(userId: string | unknown): Promise<any> {
 }
 
 async function persistNewUser(user: User): Promise<any> {
-    const url = `${process.env.PERSONALIZATION_URL}/user_preferences`;
+    const url = `${process.env.BACKEND_URL}/api/user_preferences`;
     try {
         const req = await fetch(url, {
             method: 'POST',
-            mode: 'cors',
-            //TODO figure out how to make post calls for API key protected APIs
-            // headers: {
-            //     'api-key' : process.env.REALM_API_KEY
-            // },
             body: JSON.stringify(user),
+            headers: { 'Content-Type': 'application/json' },
         });
         return await req.json();
     } catch (e) {
@@ -89,17 +83,16 @@ export const nextAuthOptions: NextAuthOptions = {
                         lastLogin: null,
                         emailPreference: false,
                     } as User);
-                    const { followed_tags, last_login, email_preference } =
+                    const { followedTags, lastLogin, emailPreference } =
                         persisted_user;
-                    session.followedTags = followed_tags;
-                    session.lastLogin = last_login;
-                    session.emailPreference = email_preference;
+                    session.followedTags = followedTags;
+                    session.lastLogin = lastLogin;
+                    session.emailPreference = emailPreference;
                 } else {
-                    const { followed_tags, last_login, email_preference } =
-                        user;
-                    session.followedTags = followed_tags;
-                    session.lastLogin = last_login;
-                    session.emailPreference = email_preference;
+                    const { followedTags, lastLogin, emailPreference } = user;
+                    session.followedTags = followedTags;
+                    session.lastLogin = lastLogin;
+                    session.emailPreference = emailPreference;
                 }
             }
             return session;

--- a/src/pages/api/userPreferences.ts
+++ b/src/pages/api/userPreferences.ts
@@ -11,12 +11,12 @@ async function userPreferencesHandler(
 
     try {
         const request = await fetch(
-            `${process.env.PERSONALIZATION_URL}/user_preferences?userId=${session?.userId}`,
+            `${process.env.BACKEND_URL}/api/user_preferences/${session?.userId}`,
             {
                 method: req.method,
                 body: req.body,
                 headers: {
-                    apiKey: process.env.REALM_API_KEY || '',
+                    'Content-Type': 'application/json',
                 },
             }
         );

--- a/src/utils/refresh-session.ts
+++ b/src/utils/refresh-session.ts
@@ -2,7 +2,6 @@
 // Next auth will refetch the session on this event, so we manually trigger it.
 
 export default function refreshSession() {
-    console.log('Displathci');
     const event = new Event('visibilitychange');
     document.dispatchEvent(event);
 }

--- a/src/utils/refresh-session.ts
+++ b/src/utils/refresh-session.ts
@@ -1,0 +1,8 @@
+// See  https://github.com/nextauthjs/next-auth/issues/596#issuecomment-943453568
+// Next auth will refetch the session on this event, so we manually trigger it.
+
+export default function refreshSession() {
+    console.log('Displathci');
+    const event = new Event('visibilitychange');
+    document.dispatchEvent(event);
+}


### PR DESCRIPTION
## Jira Ticket:

Partially related to [DEVHUB-1606](https://jira.mongodb.org/browse/DEVHUB-1606).

## Description:

Implements the backend connectivity for the FollowLink component. There were some weird things about this:
* Added a hacky way to refresh the session manually. It is imperfect though since it just emits an event on the browser and we can't await the refresh.
* Added an extra state `isShowingFollowing` to manually control what the link displays. This was necessary because after we make the API call to update the user, we trigger an event to refresh the session. However, we have no way of knowing when the new request to get the session will complete, since it is just triggered by an event we emit. In order to avoid sync issues between the button text and the tooltip text, I created this state to provide a clean UI experience. This state is reset to the session value in the `useEffect`, so even if it happens to be out of sync with the actual session, it will fall back to the correct value eventually.
* Needed to add some debouncing logic, but had to change the original function since it was being reevaluated every time we called it since it toggles `isShowingFollowing`.

