### PR TITLE
[DEVHUB-1701]: Toast components for personalization error states

### DIFF
--- a/src/components/modal/personalization/paginated/personalization-paginated.modal.tsx
+++ b/src/components/modal/personalization/paginated/personalization-paginated.modal.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mdb/flora';
 import { TopicCard } from '@mdb/devcenter-components';
 import { useModalContext } from '../../../../contexts/modal';
+import { useNotificationContext } from '../../../../contexts/notification';
 import paginationConfig from '../../../../service/get-personalization-modal-config.preval';
 import { Tag } from '../../../../interfaces/tag';
 import { submitPersonalizationSelections } from '../utils';
@@ -19,6 +20,7 @@ import styles from '../styles';
 
 const PaginatedPersonalizationModal = () => {
     const { closeModal } = useModalContext();
+    const { setNotification } = useNotificationContext();
 
     const [tabIndex, setTabIndex] = useState(0);
     const [isOptedIn, setIsOptedIn] = useState(true);
@@ -39,12 +41,26 @@ const PaginatedPersonalizationModal = () => {
         return setSelections(currSelections => [...currSelections, tag]);
     };
 
-    const onCompletion = () => {
-        submitPersonalizationSelections({
+    const onCompletion = async () => {
+        const { error } = await submitPersonalizationSelections({
             followedTags: selections,
             emailPreference: isOptedIn,
         });
+
         closeModal();
+
+        if (!error) {
+            setNotification({
+                message: 'Successfully saved your preferences',
+                variant: 'SUCCESS',
+            });
+        } else {
+            setNotification({
+                message:
+                    'Your request could not be completed at this time. Please try again.',
+                variant: 'WARN',
+            });
+        }
     };
 
     return (

--- a/src/components/modal/personalization/paginated/personalization-paginated.modal.tsx
+++ b/src/components/modal/personalization/paginated/personalization-paginated.modal.tsx
@@ -42,12 +42,12 @@ const PaginatedPersonalizationModal = () => {
     };
 
     const onCompletion = async () => {
+        closeModal();
+
         const { error } = await submitPersonalizationSelections({
             followedTags: selections,
             emailPreference: isOptedIn,
         });
-
-        closeModal();
 
         if (!error) {
             setNotification({

--- a/src/components/modal/personalization/scroll/personalization-scroll.modal.tsx
+++ b/src/components/modal/personalization/scroll/personalization-scroll.modal.tsx
@@ -3,6 +3,7 @@ import { Grid } from 'theme-ui';
 import { Button, TypographyScale, Checkbox } from '@mdb/flora';
 import { TopicCard } from '@mdb/devcenter-components';
 import { useModalContext } from '../../../../contexts/modal';
+import { useNotificationContext } from '../../../../contexts/notification';
 import tagConfig from '../../../../service/get-personalization-modal-config.preval';
 import { Tag } from '../../../../interfaces/tag';
 import { ScrollModalProps } from '../types';
@@ -17,6 +18,7 @@ const ScrollPersonalizationModal = ({
     existingSelections = [],
 }: ScrollModalProps) => {
     const { closeModal } = useModalContext();
+    const { setNotification } = useNotificationContext();
 
     const [isOptedIn, setIsOptedIn] = useState(true);
     const [selections, setSelections] =
@@ -34,12 +36,26 @@ const ScrollPersonalizationModal = ({
         return setSelections(currSelections => [...currSelections, tag]);
     };
 
-    const onCompletion = () => {
-        submitPersonalizationSelections({
+    const onCompletion = async () => {
+        const { error } = await submitPersonalizationSelections({
             followedTags: selections,
             emailPreference: isOptedIn,
         });
+
         closeModal();
+
+        if (!error) {
+            setNotification({
+                message: 'Successfully saved your preferences',
+                variant: 'SUCCESS',
+            });
+        } else {
+            setNotification({
+                message:
+                    'Your request could not be completed at this time. Please try again.',
+                variant: 'WARN',
+            });
+        }
     };
 
     return (

--- a/src/components/modal/personalization/scroll/personalization-scroll.modal.tsx
+++ b/src/components/modal/personalization/scroll/personalization-scroll.modal.tsx
@@ -37,12 +37,12 @@ const ScrollPersonalizationModal = ({
     };
 
     const onCompletion = async () => {
+        closeModal();
+
         const { error } = await submitPersonalizationSelections({
             followedTags: selections,
             emailPreference: isOptedIn,
         });
-
-        closeModal();
 
         if (!error) {
             setNotification({

--- a/src/components/modal/personalization/utils.ts
+++ b/src/components/modal/personalization/utils.ts
@@ -48,8 +48,8 @@ export async function submitPersonalizationSelections({
         );
         refreshSession();
         const res = await req.json();
-        return res; // there's no current plan to display success/failure to user
+        return res;
     } catch {
-        console.error('Could not update user preferences');
+        return { error: 'Could not update user preferences' };
     }
 }

--- a/src/components/notification/index.ts
+++ b/src/components/notification/index.ts
@@ -1,0 +1,3 @@
+import { Notification, NotificationsContainer } from './notification';
+
+export { Notification, NotificationsContainer };

--- a/src/components/notification/notification.tsx
+++ b/src/components/notification/notification.tsx
@@ -28,8 +28,8 @@ export function Notification({
     message,
     variant,
     customStyles,
-    dismissCb = () => null,
     autoDismiss = false,
+    dismissCb = () => null,
 }: NotificationProps) {
     const icon = useMemo(() => {
         let type = ESystemIconNames.CIRCLE_ALERT;
@@ -69,18 +69,15 @@ export function NotificationsContainer() {
 
     return (
         <div sx={styles.container}>
-            {notifications.length > 0 &&
-                notifications.map(({ id, message, variant }) => {
-                    return (
-                        <Notification
-                            key={id}
-                            // autoDismiss
-                            message={message}
-                            variant={variant}
-                            dismissCb={() => clearNotification(id)}
-                        />
-                    );
-                })}
+            {notifications.map(({ id, message, variant }) => (
+                <Notification
+                    key={id}
+                    autoDismiss
+                    message={message}
+                    variant={variant}
+                    dismissCb={() => clearNotification(id)}
+                />
+            ))}
         </div>
     );
 }

--- a/src/components/notification/notification.tsx
+++ b/src/components/notification/notification.tsx
@@ -1,0 +1,86 @@
+import { useMemo, useEffect } from 'react';
+import { ThemeUICSSObject } from 'theme-ui';
+import { ESystemIconNames, SystemIcon, TypographyScale } from '@mdb/flora';
+
+import { NOTIFICATION } from '../../types/notification-type';
+import { useNotificationContext } from '../../contexts/notification';
+
+import styles from './styles';
+
+interface NotificationProps {
+    message: string;
+    variant: NOTIFICATION;
+    customStyles?: ThemeUICSSObject;
+    autoDismiss?: boolean;
+    dismissCb?: () => void;
+}
+
+type VariantStyles = {
+    info: ThemeUICSSObject;
+    warn: ThemeUICSSObject;
+    success: ThemeUICSSObject;
+    error: ThemeUICSSObject;
+};
+
+const DISPLAY_NOTIFICATION_MS = 2000;
+
+export function Notification({
+    message,
+    variant,
+    customStyles,
+    dismissCb = () => null,
+    autoDismiss = false,
+}: NotificationProps) {
+    const icon = useMemo(() => {
+        let type = ESystemIconNames.CIRCLE_ALERT;
+
+        if (variant === 'SUCCESS') {
+            type = ESystemIconNames.CIRCLE_CHECK;
+        } else if (variant === 'INFO') {
+            type = ESystemIconNames.CIRCLE_INFO;
+        }
+
+        return type;
+    }, [variant]);
+
+    useEffect(() => {
+        if (autoDismiss) {
+            const timer = setTimeout(dismissCb, DISPLAY_NOTIFICATION_MS);
+            return () => clearTimeout(timer);
+        }
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return (
+        <div
+            sx={{
+                ...styles.notification,
+                ...styles[variant.toLowerCase() as keyof VariantStyles],
+                ...customStyles,
+            }}
+        >
+            <SystemIcon size="medium" sx={styles.icon} name={icon} />
+            <TypographyScale variant="body3">{message}</TypographyScale>
+        </div>
+    );
+}
+
+export function NotificationsContainer() {
+    const { notifications, clearNotification } = useNotificationContext();
+
+    return (
+        <div sx={styles.container}>
+            {notifications.length > 0 &&
+                notifications.map(({ id, message, variant }) => {
+                    return (
+                        <Notification
+                            key={id}
+                            // autoDismiss
+                            message={message}
+                            variant={variant}
+                            dismissCb={() => clearNotification(id)}
+                        />
+                    );
+                })}
+        </div>
+    );
+}

--- a/src/components/notification/styles.ts
+++ b/src/components/notification/styles.ts
@@ -1,0 +1,85 @@
+import theme from '@mdb/flora/theme';
+import { ThemeUICSSObject } from 'theme-ui';
+
+const container: ThemeUICSSObject = {
+    position: 'fixed',
+    bottom: 24,
+    left: [24, null, null, 48],
+    right: [24, null, null, 0],
+    zIndex: 20,
+    '> div': {
+        height: ['100%', '80px'],
+        width: ['100%', '414px'],
+        marginBottom: 'inc30',
+    },
+};
+
+const notification = {
+    display: 'flex',
+    alignItems: 'center',
+    borderRadius: 'inc40',
+    py: ['inc20', null, null, 'inc30'],
+    px: ['inc30', null, null, 'inc40'],
+    boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
+};
+
+const success = {
+    border: `1px solid ${theme.colors.green10}`,
+    backgroundColor: theme.colors.green05,
+    span: {
+        color: theme.colors.green70,
+    },
+    svg: {
+        stroke: theme.colors.green70,
+    },
+};
+
+const error = {
+    border: `1px solid ${theme.colors.red10}`,
+    backgroundColor: theme.colors.red05,
+    span: {
+        color: theme.colors.red60,
+    },
+    svg: {
+        stroke: theme.colors.red60,
+    },
+};
+
+const info = {
+    border: `1px solid ${theme.colors.blue10}`,
+    backgroundColor: theme.colors.blue05,
+    span: {
+        color: theme.colors.blue70,
+    },
+    svg: {
+        stroke: theme.colors.blue70,
+    },
+};
+
+const warn = {
+    border: `1px solid ${theme.colors.yellow20}`,
+    backgroundColor: theme.colors.yellow05,
+    span: {
+        color: theme.colors.yellow70,
+    },
+    svg: {
+        stroke: theme.colors.yellow70,
+    },
+};
+
+const icon = {
+    marginRight: 'inc30',
+    minWidth: 24,
+};
+
+const styles = {
+    container,
+    notification,
+    success,
+    error,
+    info,
+    warn,
+    icon,
+};
+
+export default styles;

--- a/src/contexts/notification.tsx
+++ b/src/contexts/notification.tsx
@@ -26,8 +26,8 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     const [notifications, setNotifications] = useState<Notification[]>([]);
 
     const setNotification = (notification: AddNotification) => {
-        setNotifications(prev => [
-            ...prev,
+        setNotifications(prevNotifications => [
+            ...prevNotifications,
             {
                 id: new Date().getTime(), // generate unique ID
                 ...notification,
@@ -36,7 +36,9 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     };
 
     const clearNotification = (id: number) => {
-        setNotifications(prev => prev.filter(n => n.id !== id));
+        setNotifications(prevNotifications =>
+            prevNotifications.filter(n => n.id !== id)
+        );
     };
 
     return (

--- a/src/contexts/notification.tsx
+++ b/src/contexts/notification.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { NOTIFICATION } from '../types/notification-type';
+
+interface AddNotification {
+    message: string;
+    variant: NOTIFICATION;
+}
+
+interface Notification {
+    id: number;
+    message: string;
+    variant: NOTIFICATION;
+}
+
+const NotificationsContext = createContext<{
+    notifications: Notification[];
+    clearNotification: (id: number) => void;
+    setNotification: (notification: AddNotification) => void;
+}>({
+    notifications: [],
+    setNotification: () => null,
+    clearNotification: () => null,
+});
+
+export function NotificationsProvider({ children }: { children: ReactNode }) {
+    const [notifications, setNotifications] = useState<Notification[]>([]);
+
+    const setNotification = (notification: AddNotification) => {
+        setNotifications(prev => [
+            ...prev,
+            {
+                id: new Date().getTime(), // generate unique ID
+                ...notification,
+            },
+        ]);
+    };
+
+    const clearNotification = (id: number) => {
+        setNotifications(prev => prev.filter(n => n.id !== id));
+    };
+
+    return (
+        <NotificationsContext.Provider
+            value={{
+                notifications,
+                setNotification,
+                clearNotification,
+            }}
+        >
+            {children}
+        </NotificationsContext.Provider>
+    );
+}
+
+export const useNotificationContext = () => useContext(NotificationsContext);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,23 +1,27 @@
-import { useRouter } from 'next/router';
-import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import getConfig from 'next/config';
 import { Session } from 'next-auth';
+import { useRouter } from 'next/router';
+import type { AppProps } from 'next/app';
 import { SessionProvider } from 'next-auth/react';
 import theme from '@mdb/flora/theme';
 import { ThemeProvider } from '@theme-ui/core';
 import { CacheProvider } from '@emotion/react';
-import { customCache } from '../utils/emotion';
+
+import { OverlayProvider } from '../contexts/overlay';
+import { ModalProvider } from '../contexts/modal';
+import { NotificationsProvider } from '../contexts/notification';
+
+import ModalRoot from '../components/modal';
+import { NotificationsContainer } from '../components/notification';
 import Layout from '../components/layout';
 import ErrorBoundary from '../components/error-boundary';
-import { OverlayProvider } from '../contexts/overlay';
 import {
     getMetaDescr,
     getCanonicalUrl,
     shouldDefineDefaultCanonical,
 } from '../utils/seo';
-import ModalRoot from '../components/modal';
-import { ModalProvider } from '../contexts/modal';
+import { customCache } from '../utils/emotion';
 
 import '../../mocks/run-msw';
 
@@ -58,16 +62,19 @@ function MyApp({ Component, pageProps, session }: AppProps & CustomProps) {
             >
                 <CacheProvider value={customCache(theme)}>
                     <ThemeProvider theme={theme}>
-                        <ModalProvider>
-                            <OverlayProvider>
-                                <Layout pagePath={pagePath}>
-                                    <ErrorBoundary>
-                                        <ModalRoot />
-                                        <Component {...pageProps} />
-                                    </ErrorBoundary>
-                                </Layout>
-                            </OverlayProvider>
-                        </ModalProvider>
+                        <NotificationsProvider>
+                            <ModalProvider>
+                                <OverlayProvider>
+                                    <Layout pagePath={pagePath}>
+                                        <ErrorBoundary>
+                                            <ModalRoot />
+                                            <NotificationsContainer />
+                                            <Component {...pageProps} />
+                                        </ErrorBoundary>
+                                    </Layout>
+                                </OverlayProvider>
+                            </ModalProvider>
+                        </NotificationsProvider>
                     </ThemeProvider>
                 </CacheProvider>
             </SessionProvider>

--- a/src/pages/api/userPreferences.ts
+++ b/src/pages/api/userPreferences.ts
@@ -21,7 +21,6 @@ async function userPreferencesHandler(
             }
         );
         if (request.status === 200) {
-            // There's no current plans to display success/failure of PUT in the UI, just return the response for now
             const response = await request.json();
             return res
                 .status(request.status)

--- a/src/types/notification-type.ts
+++ b/src/types/notification-type.ts
@@ -1,0 +1,1 @@
+export type NOTIFICATION = 'INFO' | 'ERROR' | 'SUCCESS' | 'WARN';


### PR DESCRIPTION
## Jira Ticket:

 [DEVHUB-1701](https://jira.mongodb.org/browse/DEVHUB-1701)

## Description:
- Adds `<Notification />`, `<NotificationContainer />` component and context to display notifications based on relevant HTTP success/errors. `<Notification />` can be used anywhere in the app to display a static notification, whereas `<NotificationContainer />` leverages `useNotificationContext` and displays notifications in the bottom lefthand corner and auto-dismisses after 2 seconds (note: this timeout number might have to be increased after trying it out on local).

STILL NEEDS TO BE DONE:
- Added to remaining places in scope of personalization changes
- Unit test(s) for notification component and contexts

## Checklist: (Check off where applicable)?
-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added tests that prove my fix is effective or that my feature works - **Still needs to be done, might need to wait until we can get the capacity**
