### PR TITLE
Fix for Recommended Content Modal

### DIFF
--- a/src/components/modal/personalization/paginated/personalization-paginated.modal.tsx
+++ b/src/components/modal/personalization/paginated/personalization-paginated.modal.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mdb/flora';
 import { TopicCard } from '@mdb/devcenter-components';
 import { useModalContext } from '../../../../contexts/modal';
+import { useNotificationContext } from '../../../../contexts/notification';
 import paginationConfig from '../../../../service/get-personalization-modal-config.preval';
 import { Tag } from '../../../../interfaces/tag';
 import { submitPersonalizationSelections } from '../utils';
@@ -19,6 +20,7 @@ import styles from '../styles';
 
 const PaginatedPersonalizationModal = () => {
     const { closeModal } = useModalContext();
+    const { setNotification } = useNotificationContext();
 
     const [tabIndex, setTabIndex] = useState(0);
     const [isOptedIn, setIsOptedIn] = useState(true);
@@ -39,12 +41,26 @@ const PaginatedPersonalizationModal = () => {
         return setSelections(currSelections => [...currSelections, tag]);
     };
 
-    const onCompletion = () => {
-        submitPersonalizationSelections({
+    const onCompletion = async () => {
+        closeModal();
+
+        const { error } = await submitPersonalizationSelections({
             followedTags: selections,
             emailPreference: isOptedIn,
         });
-        closeModal();
+
+        if (!error) {
+            setNotification({
+                message: 'Successfully saved your preferences',
+                variant: 'SUCCESS',
+            });
+        } else {
+            setNotification({
+                message:
+                    'Your request could not be completed at this time. Please try again.',
+                variant: 'WARN',
+            });
+        }
     };
 
     return (

--- a/src/components/modal/personalization/scroll/personalization-scroll.modal.tsx
+++ b/src/components/modal/personalization/scroll/personalization-scroll.modal.tsx
@@ -3,6 +3,7 @@ import { Grid } from 'theme-ui';
 import { Button, TypographyScale, Checkbox } from '@mdb/flora';
 import { TopicCard } from '@mdb/devcenter-components';
 import { useModalContext } from '../../../../contexts/modal';
+import { useNotificationContext } from '../../../../contexts/notification';
 import tagConfig from '../../../../service/get-personalization-modal-config.preval';
 import { Tag } from '../../../../interfaces/tag';
 import { ScrollModalProps } from '../types';
@@ -17,6 +18,7 @@ const ScrollPersonalizationModal = ({
     existingSelections = [],
 }: ScrollModalProps) => {
     const { closeModal } = useModalContext();
+    const { setNotification } = useNotificationContext();
 
     const [isOptedIn, setIsOptedIn] = useState(true);
     const [selections, setSelections] =
@@ -34,12 +36,26 @@ const ScrollPersonalizationModal = ({
         return setSelections(currSelections => [...currSelections, tag]);
     };
 
-    const onCompletion = () => {
-        submitPersonalizationSelections({
+    const onCompletion = async () => {
+        closeModal();
+
+        const { error } = await submitPersonalizationSelections({
             followedTags: selections,
             emailPreference: isOptedIn,
         });
-        closeModal();
+
+        if (!error) {
+            setNotification({
+                message: 'Successfully saved your preferences',
+                variant: 'SUCCESS',
+            });
+        } else {
+            setNotification({
+                message:
+                    'Your request could not be completed at this time. Please try again.',
+                variant: 'WARN',
+            });
+        }
     };
 
     return (

--- a/src/components/modal/personalization/utils.ts
+++ b/src/components/modal/personalization/utils.ts
@@ -48,8 +48,8 @@ export async function submitPersonalizationSelections({
         );
         refreshSession();
         const res = await req.json();
-        return res; // there's no current plan to display success/failure to user
+        return res;
     } catch {
-        console.error('Could not update user preferences');
+        return { error: 'Could not update user preferences' };
     }
 }

--- a/src/components/notification/index.ts
+++ b/src/components/notification/index.ts
@@ -1,0 +1,3 @@
+import { Notification, NotificationsContainer } from './notification';
+
+export { Notification, NotificationsContainer };

--- a/src/components/notification/notification.tsx
+++ b/src/components/notification/notification.tsx
@@ -1,0 +1,83 @@
+import { useMemo, useEffect } from 'react';
+import { ThemeUICSSObject } from 'theme-ui';
+import { ESystemIconNames, SystemIcon, TypographyScale } from '@mdb/flora';
+
+import { NOTIFICATION } from '../../types/notification-type';
+import { useNotificationContext } from '../../contexts/notification';
+
+import styles from './styles';
+
+interface NotificationProps {
+    message: string;
+    variant: NOTIFICATION;
+    customStyles?: ThemeUICSSObject;
+    autoDismiss?: boolean;
+    dismissCb?: () => void;
+}
+
+type VariantStyles = {
+    info: ThemeUICSSObject;
+    warn: ThemeUICSSObject;
+    success: ThemeUICSSObject;
+    error: ThemeUICSSObject;
+};
+
+const DISPLAY_NOTIFICATION_MS = 2000;
+
+export function Notification({
+    message,
+    variant,
+    customStyles,
+    autoDismiss = false,
+    dismissCb = () => null,
+}: NotificationProps) {
+    const icon = useMemo(() => {
+        let type = ESystemIconNames.CIRCLE_ALERT;
+
+        if (variant === 'SUCCESS') {
+            type = ESystemIconNames.CIRCLE_CHECK;
+        } else if (variant === 'INFO') {
+            type = ESystemIconNames.CIRCLE_INFO;
+        }
+
+        return type;
+    }, [variant]);
+
+    useEffect(() => {
+        if (autoDismiss) {
+            const timer = setTimeout(dismissCb, DISPLAY_NOTIFICATION_MS);
+            return () => clearTimeout(timer);
+        }
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return (
+        <div
+            sx={{
+                ...styles.notification,
+                ...styles[variant.toLowerCase() as keyof VariantStyles],
+                ...customStyles,
+            }}
+        >
+            <SystemIcon size="medium" sx={styles.icon} name={icon} />
+            <TypographyScale variant="body3">{message}</TypographyScale>
+        </div>
+    );
+}
+
+export function NotificationsContainer() {
+    const { notifications, clearNotification } = useNotificationContext();
+
+    return (
+        <div sx={styles.container}>
+            {notifications.map(({ id, message, variant }) => (
+                <Notification
+                    key={id}
+                    autoDismiss
+                    message={message}
+                    variant={variant}
+                    dismissCb={() => clearNotification(id)}
+                />
+            ))}
+        </div>
+    );
+}

--- a/src/components/notification/styles.ts
+++ b/src/components/notification/styles.ts
@@ -1,0 +1,85 @@
+import theme from '@mdb/flora/theme';
+import { ThemeUICSSObject } from 'theme-ui';
+
+const container: ThemeUICSSObject = {
+    position: 'fixed',
+    bottom: 24,
+    left: [24, null, null, 48],
+    right: [24, null, null, 0],
+    zIndex: 20,
+    '> div': {
+        height: ['100%', '80px'],
+        width: ['100%', '414px'],
+        marginBottom: 'inc30',
+    },
+};
+
+const notification = {
+    display: 'flex',
+    alignItems: 'center',
+    borderRadius: 'inc40',
+    py: ['inc20', null, null, 'inc30'],
+    px: ['inc30', null, null, 'inc40'],
+    boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
+};
+
+const success = {
+    border: `1px solid ${theme.colors.green10}`,
+    backgroundColor: theme.colors.green05,
+    span: {
+        color: theme.colors.green70,
+    },
+    svg: {
+        stroke: theme.colors.green70,
+    },
+};
+
+const error = {
+    border: `1px solid ${theme.colors.red10}`,
+    backgroundColor: theme.colors.red05,
+    span: {
+        color: theme.colors.red60,
+    },
+    svg: {
+        stroke: theme.colors.red60,
+    },
+};
+
+const info = {
+    border: `1px solid ${theme.colors.blue10}`,
+    backgroundColor: theme.colors.blue05,
+    span: {
+        color: theme.colors.blue70,
+    },
+    svg: {
+        stroke: theme.colors.blue70,
+    },
+};
+
+const warn = {
+    border: `1px solid ${theme.colors.yellow20}`,
+    backgroundColor: theme.colors.yellow05,
+    span: {
+        color: theme.colors.yellow70,
+    },
+    svg: {
+        stroke: theme.colors.yellow70,
+    },
+};
+
+const icon = {
+    marginRight: 'inc30',
+    minWidth: 24,
+};
+
+const styles = {
+    container,
+    notification,
+    success,
+    error,
+    info,
+    warn,
+    icon,
+};
+
+export default styles;

--- a/src/components/recommended-section/recommended-section.test.tsx
+++ b/src/components/recommended-section/recommended-section.test.tsx
@@ -84,6 +84,6 @@ describe('Recommended Section', () => {
         await userEvent.click(checkbox);
         await userEvent.click(saveBtn);
 
-        expect(mockTagsSaved).toBeCalledWith([MOCK_ARTICLE_TAGS[0]], true);
+        expect(mockTagsSaved).toBeCalledWith([MOCK_ARTICLE_TAGS[0]], false);
     });
 });

--- a/src/components/recommended-section/recommended-section.tsx
+++ b/src/components/recommended-section/recommended-section.tsx
@@ -16,6 +16,7 @@ import { RecommendedContentData } from '../../hooks/personalization';
 
 interface RecommendedSectionProps {
     tags?: Tag[];
+    followedTags?: Tag[];
     content?: RecommendedContentData;
     onTagsSaved?: (tags: Tag[], digestChecked: boolean) => void;
     onTagSelected?: (tag: Tag, allSelectedTags: Tag[]) => void;
@@ -24,6 +25,7 @@ interface RecommendedSectionProps {
 
 const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
     tags = [],
+    followedTags = [],
     content: { contentItems = [] } = {},
     content,
     showFooter = true,
@@ -38,11 +40,13 @@ const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
             <ScrollPersonalizationModal
                 title="What topics are you interested in?"
                 subtitle="Follow topics for personalized recommendations"
-                existingSelections={selectedTags}
+                existingSelections={
+                    followedTags.length ? followedTags : selectedTags
+                }
             />,
             { hideCloseBtn: true }
         );
-    }, [openModal, selectedTags]);
+    }, [openModal, followedTags, selectedTags]);
 
     return !!tags.length || !!contentItems.length ? (
         <div sx={recommendedSectionStyles}>

--- a/src/components/recommended-section/recommended-tag-section.tsx
+++ b/src/components/recommended-section/recommended-tag-section.tsx
@@ -88,6 +88,7 @@ const RecommendedTagSection: React.FunctionComponent<
                         onToggle={setDigestChecked}
                         label="Receive a monthly digest with new content based on topics you follow"
                         name="digest-checkbox"
+                        checked
                     />
 
                     <div sx={topicSaveButtonWrapperStyles}>

--- a/src/contexts/notification.tsx
+++ b/src/contexts/notification.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { NOTIFICATION } from '../types/notification-type';
+
+interface AddNotification {
+    message: string;
+    variant: NOTIFICATION;
+}
+
+interface Notification {
+    id: number;
+    message: string;
+    variant: NOTIFICATION;
+}
+
+const NotificationsContext = createContext<{
+    notifications: Notification[];
+    clearNotification: (id: number) => void;
+    setNotification: (notification: AddNotification) => void;
+}>({
+    notifications: [],
+    setNotification: () => null,
+    clearNotification: () => null,
+});
+
+export function NotificationsProvider({ children }: { children: ReactNode }) {
+    const [notifications, setNotifications] = useState<Notification[]>([]);
+
+    const setNotification = (notification: AddNotification) => {
+        setNotifications(prevNotifications => [
+            ...prevNotifications,
+            {
+                id: new Date().getTime(), // generate unique ID
+                ...notification,
+            },
+        ]);
+    };
+
+    const clearNotification = (id: number) => {
+        setNotifications(prevNotifications =>
+            prevNotifications.filter(n => n.id !== id)
+        );
+    };
+
+    return (
+        <NotificationsContext.Provider
+            value={{
+                notifications,
+                setNotification,
+                clearNotification,
+            }}
+        >
+            {children}
+        </NotificationsContext.Provider>
+    );
+}
+
+export const useNotificationContext = () => useContext(NotificationsContext);

--- a/src/hooks/personalization/index.ts
+++ b/src/hooks/personalization/index.ts
@@ -33,7 +33,7 @@ const fetcher: Fetcher<{ data: RecommendedContentResponseData }, string> = (
 };
 
 const buildQuery = (tags: Tag[]) => {
-    // TODO: Replace with correct query string logic
+    // Keep tags sorted so cache functions properly
     return tags
         .sort((a: Tag, b: Tag) =>
             `${a.type}${a.name}` > `${b.type}${b.name}` ? 1 : -1

--- a/src/hooks/personalization/index.ts
+++ b/src/hooks/personalization/index.ts
@@ -21,22 +21,24 @@ interface RecommendedContentResponse {
     mutate: KeyedMutator<{ data: RecommendedContentResponseData }>;
 }
 
-const fetcher: Fetcher<
-    { data: RecommendedContentResponseData },
-    string
-> = () => {
-    return fetch(getURLPath('/api/personalized-content') as string).then(
-        async response => {
-            const json = await response.json();
-            return json;
-        }
-    );
+const fetcher: Fetcher<{ data: RecommendedContentResponseData }, string> = (
+    query: string
+) => {
+    return fetch(
+        (getURLPath('/api/personalized-content') as string) + '?' + query
+    ).then(async response => {
+        const json = await response.json();
+        return json;
+    });
 };
 
 const buildQuery = (tags: Tag[]) => {
     // TODO: Replace with correct query string logic
     return tags
-        .reduce((acc, tag) => acc + `${tag.type}=${tag.name},`, '')
+        .sort((a: Tag, b: Tag) =>
+            `${a.type}${a.name}` > `${b.type}${b.name}` ? 1 : -1
+        )
+        .reduce((acc, tag) => acc + `${tag.type}=${tag.name}&`, '')
         .slice(0, -1);
 };
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,23 +1,27 @@
-import { useRouter } from 'next/router';
-import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import getConfig from 'next/config';
 import { Session } from 'next-auth';
+import { useRouter } from 'next/router';
+import type { AppProps } from 'next/app';
 import { SessionProvider } from 'next-auth/react';
 import theme from '@mdb/flora/theme';
 import { ThemeProvider } from '@theme-ui/core';
 import { CacheProvider } from '@emotion/react';
-import { customCache } from '../utils/emotion';
+
+import { OverlayProvider } from '../contexts/overlay';
+import { ModalProvider } from '../contexts/modal';
+import { NotificationsProvider } from '../contexts/notification';
+
+import ModalRoot from '../components/modal';
+import { NotificationsContainer } from '../components/notification';
 import Layout from '../components/layout';
 import ErrorBoundary from '../components/error-boundary';
-import { OverlayProvider } from '../contexts/overlay';
 import {
     getMetaDescr,
     getCanonicalUrl,
     shouldDefineDefaultCanonical,
 } from '../utils/seo';
-import ModalRoot from '../components/modal';
-import { ModalProvider } from '../contexts/modal';
+import { customCache } from '../utils/emotion';
 
 import '../../mocks/run-msw';
 
@@ -58,16 +62,19 @@ function MyApp({ Component, pageProps, session }: AppProps & CustomProps) {
             >
                 <CacheProvider value={customCache(theme)}>
                     <ThemeProvider theme={theme}>
-                        <ModalProvider>
-                            <OverlayProvider>
-                                <Layout pagePath={pagePath}>
-                                    <ErrorBoundary>
-                                        <ModalRoot />
-                                        <Component {...pageProps} />
-                                    </ErrorBoundary>
-                                </Layout>
-                            </OverlayProvider>
-                        </ModalProvider>
+                        <NotificationsProvider>
+                            <ModalProvider>
+                                <OverlayProvider>
+                                    <Layout pagePath={pagePath}>
+                                        <ErrorBoundary>
+                                            <ModalRoot />
+                                            <NotificationsContainer />
+                                            <Component {...pageProps} />
+                                        </ErrorBoundary>
+                                    </Layout>
+                                </OverlayProvider>
+                            </ModalProvider>
+                        </NotificationsProvider>
                     </ThemeProvider>
                 </CacheProvider>
             </SessionProvider>

--- a/src/pages/api/userPreferences.ts
+++ b/src/pages/api/userPreferences.ts
@@ -21,7 +21,6 @@ async function userPreferencesHandler(
             }
         );
         if (request.status === 200) {
-            // There's no current plans to display success/failure of PUT in the UI, just return the response for now
             const response = await request.json();
             return res
                 .status(request.status)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -82,10 +82,9 @@ const Home: React.FunctionComponent<HomeProps & NextPage> = ({
     recommendedTags,
 }) => {
     const { status, data } = useSession();
-    const { followedTags } = data || {};
-    const { data: content, isValidating } = usePersonalizedContent(
-        followedTags || []
-    );
+    const followedTags = data?.followedTags || [];
+    const { data: content, isValidating } =
+        usePersonalizedContent(followedTags);
 
     return (
         <main
@@ -155,13 +154,13 @@ const Home: React.FunctionComponent<HomeProps & NextPage> = ({
             {status === 'authenticated' && !isValidating && (
                 <RecommendedSection
                     tags={recommendedTags}
+                    followedTags={followedTags}
                     content={content}
                     showFooter
                     onTagsSaved={(
                         followedTags: Tag[],
                         emailPreference: boolean
                     ) => {
-                        // TODO: Replace with call to user preferences endpoint
                         submitPersonalizationSelections({
                             followedTags,
                             emailPreference,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,6 +28,7 @@ import { useSession } from 'next-auth/react';
 import { Tag } from '../interfaces/tag';
 import usePersonalizedContent from '../hooks/personalization';
 import { submitPersonalizationSelections } from '../components/modal/personalization/utils';
+import { useNotificationContext } from '../contexts/notification';
 
 const getImageSrc = (imageString: string | EThirdPartyLogoVariant) =>
     (
@@ -85,6 +86,7 @@ const Home: React.FunctionComponent<HomeProps & NextPage> = ({
     const followedTags = data?.followedTags || [];
     const { data: content, isValidating } =
         usePersonalizedContent(followedTags);
+    const { setNotification } = useNotificationContext();
 
     return (
         <main
@@ -164,6 +166,20 @@ const Home: React.FunctionComponent<HomeProps & NextPage> = ({
                         submitPersonalizationSelections({
                             followedTags,
                             emailPreference,
+                        }).then(({ error }) => {
+                            if (!error) {
+                                setNotification({
+                                    message:
+                                        'Successfully saved your preferences',
+                                    variant: 'SUCCESS',
+                                });
+                            } else {
+                                setNotification({
+                                    message:
+                                        'Your request could not be completed at this time. Please try again.',
+                                    variant: 'WARN',
+                                });
+                            }
                         });
                     }}
                 />

--- a/src/types/notification-type.ts
+++ b/src/types/notification-type.ts
@@ -1,0 +1,1 @@
+export type NOTIFICATION = 'INFO' | 'ERROR' | 'SUCCESS' | 'WARN';


### PR DESCRIPTION
Quick fix/follow up to https://github.com/mongodb/devcenter/pull/448
Bringing up the personalization modal when a user has followed topics would always display no tags selected. Now, the tags initially selected should reflect what the user is currently following.

edit: also fixed caching behavior that was noticed with recommended content endpoint