### PR TITLE
[DEVHUB-1703] Implement remaining notifications.

### DIFF
--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -19,6 +19,7 @@ declare module 'next-auth' {
         followedTags?: Tag[] | null;
         lastLogin: string | null;
         emailPreference: boolean;
+        failedToFetch?: boolean;
     }
 
     interface Profile {

--- a/src/components/follow-link/follow-link.tsx
+++ b/src/components/follow-link/follow-link.tsx
@@ -101,7 +101,16 @@ const FollowLink: React.FunctionComponent<FollowLinkProps> = ({
                 emailPreference: session.emailPreference,
             });
         },
-        [followedTopics, topic, session?.failedToFetch]
+        [
+            followedTopics,
+            topic,
+            session?.failedToFetch,
+            session?.emailPreference,
+            isFollowingAnyTopics,
+            openModal,
+            setNotification,
+            updateUserPreferences,
+        ]
     );
 
     const debouncedOnFollowClick = useMemo(

--- a/src/components/follow-link/follow-link.tsx
+++ b/src/components/follow-link/follow-link.tsx
@@ -8,7 +8,7 @@ import { Tag } from '../../interfaces/tag';
 import Tooltip from '../tooltip/tooltip';
 import { useModalContext } from '../../contexts/modal';
 import { ScrollPersonalizationModal } from '../modal/personalization';
-import { submitPersonalizationSelections } from '../modal/personalization/utils';
+import useUserPreferences from '../../hooks/personalization/user-preferences';
 import { DEBOUNCE_WAIT } from '../../data/constants';
 
 interface FollowLinkProps {
@@ -20,11 +20,8 @@ const FollowLink: React.FunctionComponent<FollowLinkProps> = ({
     topic,
     iconsOnly = false,
 }) => {
+    const { updateUserPreferences } = useUserPreferences();
     const { status, data: session } = useSession();
-
-    const [showClickTooltip, setShowClickTooltip] = useState(false);
-
-    const [timeoutID, setTimeoutID] = useState<NodeJS.Timeout | null>(null);
 
     const followedTopics = session?.followedTags;
     const isFollowing = !!(
@@ -62,8 +59,10 @@ const FollowLink: React.FunctionComponent<FollowLinkProps> = ({
 
     const onFollowClick = useCallback(
         (currentlyFollowing: boolean) => {
+            if (session?.failedToFetch) {
+                alert('Failed to fetch so not executing');
+            }
             let followedTags: Tag[];
-            // Never show the click tooltip when using the iconsOnly variant
             setIsShowingFollowing(!currentlyFollowing);
             if (!isFollowingAnyTopics) {
                 openModal(
@@ -90,21 +89,12 @@ const FollowLink: React.FunctionComponent<FollowLinkProps> = ({
                     ? [...followedTopics, topic]
                     : [topic];
             }
-            if (!iconsOnly) {
-                if (timeoutID) {
-                    // To prevent a follow and unfollow action in under 2 seconds from having it's click tooltip dissapear prematurely.
-                    clearTimeout(timeoutID);
-                }
-                setShowClickTooltip(true);
-                const id = setTimeout(() => setShowClickTooltip(false), 2000);
-                setTimeoutID(id);
-            }
-            submitPersonalizationSelections({
+            updateUserPreferences({
                 followedTags,
                 emailPreference: session.emailPreference,
             });
         },
-        [followedTopics, topic]
+        [followedTopics, topic, session?.failedToFetch]
     );
 
     const debouncedOnFollowClick = useMemo(
@@ -159,12 +149,6 @@ const FollowLink: React.FunctionComponent<FollowLinkProps> = ({
                 </Link>
             </div>
             <Tooltip className="tooltip">{hoverTooltipText}</Tooltip>
-            {showClickTooltip && (
-                <Tooltip>
-                    You are {isShowingFollowing ? 'now' : 'no longer'} following
-                    this topic
-                </Tooltip>
-            )}
         </div>
     );
 };

--- a/src/components/follow-link/follow-link.tsx
+++ b/src/components/follow-link/follow-link.tsx
@@ -9,6 +9,7 @@ import Tooltip from '../tooltip/tooltip';
 import { useModalContext } from '../../contexts/modal';
 import { ScrollPersonalizationModal } from '../modal/personalization';
 import useUserPreferences from '../../hooks/personalization/user-preferences';
+import { useNotificationContext } from '../../contexts/notification';
 import { DEBOUNCE_WAIT } from '../../data/constants';
 
 interface FollowLinkProps {
@@ -21,6 +22,7 @@ const FollowLink: React.FunctionComponent<FollowLinkProps> = ({
     iconsOnly = false,
 }) => {
     const { updateUserPreferences } = useUserPreferences();
+    const { setNotification } = useNotificationContext();
     const { status, data: session } = useSession();
 
     const followedTopics = session?.followedTags;
@@ -60,7 +62,12 @@ const FollowLink: React.FunctionComponent<FollowLinkProps> = ({
     const onFollowClick = useCallback(
         (currentlyFollowing: boolean) => {
             if (session?.failedToFetch) {
-                alert('Failed to fetch so not executing');
+                setNotification({
+                    message:
+                        'Your request could not be completed at this time. Please try again.',
+                    variant: 'WARN',
+                });
+                return;
             }
             let followedTags: Tag[];
             setIsShowingFollowing(!currentlyFollowing);

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -36,7 +36,8 @@ const Layout: React.FunctionComponent<LayoutProps> = ({
     const { data: session } = useSession();
 
     useEffect(() => {
-        if (session && !session?.lastLogin) {
+        if (session && !session.lastLogin && !session.failedToFetch) {
+            // Don't spam with the modal if we failed to fetch.
             openModal(
                 <PaginatedPersonalizationModal />,
                 // Pass default values to PUT if user dismisses the modal so their "lastLogin" flag can be updated

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -11,8 +11,8 @@ import { layers } from '../styled/layout';
 import { useEnsureImageAlts } from '../utils/seo';
 import { useModalContext } from '../contexts/modal';
 import { PaginatedPersonalizationModal } from './modal/personalization';
-import { submitPersonalizationSelections } from './modal/personalization/utils';
 import getSignInURL from '../utils/get-sign-in-url';
+import useUserPreferences from '../hooks/personalization/user-preferences';
 
 const navStyles = {
     'nav > div > div > ul': {
@@ -30,6 +30,7 @@ const Layout: React.FunctionComponent<LayoutProps> = ({
     children,
     pagePath,
 }) => {
+    const { updateUserPreferences } = useUserPreferences();
     const { hasOverlay } = useContext(OverlayContext);
     const { component: hasModalOpen, openModal } = useModalContext();
     const { data: session } = useSession();
@@ -41,7 +42,7 @@ const Layout: React.FunctionComponent<LayoutProps> = ({
                 // Pass default values to PUT if user dismisses the modal so their "lastLogin" flag can be updated
                 {
                     onCloseCallback: () =>
-                        submitPersonalizationSelections({
+                        updateUserPreferences({
                             followedTags: [],
                             emailPreference: false,
                         }),

--- a/src/components/modal/personalization/paginated/personalization-paginated.modal.tsx
+++ b/src/components/modal/personalization/paginated/personalization-paginated.modal.tsx
@@ -12,12 +12,13 @@ import { TopicCard } from '@mdb/devcenter-components';
 import { useModalContext } from '../../../../contexts/modal';
 import paginationConfig from '../../../../service/get-personalization-modal-config.preval';
 import { Tag } from '../../../../interfaces/tag';
-import { submitPersonalizationSelections } from '../utils';
+import useUserPreferences from '../../../../hooks/personalization/user-preferences';
 import { tagToTopic } from '../../../../utils/tag-to-topic';
 
 import styles from '../styles';
 
 const PaginatedPersonalizationModal = () => {
+    const { updateUserPreferences } = useUserPreferences();
     const { closeModal } = useModalContext();
 
     const [tabIndex, setTabIndex] = useState(0);
@@ -40,7 +41,7 @@ const PaginatedPersonalizationModal = () => {
     };
 
     const onCompletion = () => {
-        submitPersonalizationSelections({
+        updateUserPreferences({
             followedTags: selections,
             emailPreference: isOptedIn,
         });

--- a/src/components/modal/personalization/scroll/personalization-scroll.modal.tsx
+++ b/src/components/modal/personalization/scroll/personalization-scroll.modal.tsx
@@ -6,7 +6,7 @@ import { useModalContext } from '../../../../contexts/modal';
 import tagConfig from '../../../../service/get-personalization-modal-config.preval';
 import { Tag } from '../../../../interfaces/tag';
 import { ScrollModalProps } from '../types';
-import { submitPersonalizationSelections } from '../utils';
+import useUserPreferences from '../../../../hooks/personalization/user-preferences';
 import { tagToTopic } from '../../../../utils/tag-to-topic';
 
 import styles from '../styles';
@@ -16,6 +16,7 @@ const ScrollPersonalizationModal = ({
     subtitle = '',
     existingSelections = [],
 }: ScrollModalProps) => {
+    const { updateUserPreferences } = useUserPreferences();
     const { closeModal } = useModalContext();
 
     const [isOptedIn, setIsOptedIn] = useState(true);
@@ -35,7 +36,7 @@ const ScrollPersonalizationModal = ({
     };
 
     const onCompletion = () => {
-        submitPersonalizationSelections({
+        updateUserPreferences({
             followedTags: selections,
             emailPreference: isOptedIn,
         });

--- a/src/components/modal/personalization/utils.ts
+++ b/src/components/modal/personalization/utils.ts
@@ -38,18 +38,21 @@ export async function submitPersonalizationSelections({
     followedTags: Array<Tag>;
     emailPreference: boolean;
 }) {
+    let req;
     try {
-        const req = await fetch(
-            getURLPath('/api/userPreferences', false) as string,
-            {
-                method: 'PUT',
-                body: JSON.stringify({ followedTags, emailPreference }),
-            }
-        );
+        req = await fetch(getURLPath('/api/userPreferences', false) as string, {
+            method: 'PUT',
+            body: JSON.stringify({ followedTags, emailPreference }),
+        });
+    } catch (err) {
         refreshSession();
-        const res = await req.json();
-        return res; // there's no current plan to display success/failure to user
-    } catch {
-        console.error('Could not update user preferences');
+        throw Error('Could not update user preferences');
     }
+    refreshSession();
+    if (req.status !== 200) {
+        throw Error('Could not update user preferences');
+    }
+
+    const res = await req.json();
+    return res; // there's no current plan to display success/failure to user
 }

--- a/src/components/recommended-section/recommended-section.tsx
+++ b/src/components/recommended-section/recommended-section.tsx
@@ -5,7 +5,6 @@ import RecommendedTagSection from './recommended-tag-section';
 import RecommendedContentSection from './recommended-content-section';
 import { useModalContext } from '../../contexts/modal';
 import { ScrollPersonalizationModal } from '../modal/personalization';
-import { useSession } from 'next-auth/react';
 import { useCallback, useState } from 'react';
 import {
     followTopicsArrowStyles,
@@ -23,6 +22,7 @@ interface RecommendedSectionProps {
     onTagsSaved?: (tags: Tag[], digestChecked: boolean) => void;
     onTagSelected?: (tag: Tag, allSelectedTags: Tag[]) => void;
     showFooter?: boolean;
+    hasContentError?: boolean;
 }
 
 const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
@@ -31,10 +31,10 @@ const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
     content: { contentItems = [] } = {},
     content,
     showFooter = true,
+    hasContentError = false,
     onTagSelected = () => undefined,
     onTagsSaved = () => undefined,
 }) => {
-    const { data: session } = useSession();
     const { openModal } = useModalContext();
     const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
 
@@ -51,7 +51,7 @@ const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
         );
     }, [openModal, followedTags, selectedTags]);
 
-    return !!tags.length || !!contentItems.length ? (
+    return !!tags.length || !!contentItems.length || !!hasContentError ? (
         <div sx={recommendedSectionStyles}>
             <TypographyScale
                 variant="heading2"
@@ -70,7 +70,7 @@ const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
                     ? 'Follow More Topics'
                     : 'View All Topics to Follow'}
             </Link>
-            {session?.failedToFetch ? (
+            {hasContentError ? (
                 <div sx={{ flexBasis: '100%', order: 1 }}>
                     <Notification
                         customStyles={{ width: 'fit-content' }}

--- a/src/components/recommended-section/recommended-section.tsx
+++ b/src/components/recommended-section/recommended-section.tsx
@@ -5,6 +5,7 @@ import RecommendedTagSection from './recommended-tag-section';
 import RecommendedContentSection from './recommended-content-section';
 import { useModalContext } from '../../contexts/modal';
 import { ScrollPersonalizationModal } from '../modal/personalization';
+import { useSession } from 'next-auth/react';
 import { useCallback, useState } from 'react';
 import {
     followTopicsArrowStyles,
@@ -13,6 +14,7 @@ import {
     recommendedSectionSubheadingStyles,
 } from './styles';
 import { RecommendedContentData } from '../../hooks/personalization';
+import { Notification } from '../notification';
 
 interface RecommendedSectionProps {
     tags?: Tag[];
@@ -30,6 +32,7 @@ const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
     onTagSelected = () => undefined,
     onTagsSaved = () => undefined,
 }) => {
+    const { data: session } = useSession();
     const { openModal } = useModalContext();
     const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
 
@@ -63,31 +66,45 @@ const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
                     ? 'Follow More Topics'
                     : 'View All Topics to Follow'}
             </Link>
-            <TypographyScale
-                variant="body1"
-                color="default"
-                sx={recommendedSectionSubheadingStyles}
-            >
-                Select topics to follow for recommended content
-            </TypographyScale>
+            {session?.failedToFetch ? (
+                <div sx={{ flexBasis: '100%', order: 1 }}>
+                    <Notification
+                        customStyles={{ width: 'fit-content' }}
+                        message="An error occurred while fetching recommended content. Please try refreshing the page."
+                        variant="WARN"
+                    />
+                </div>
+            ) : (
+                <>
+                    <TypographyScale
+                        variant="body1"
+                        color="default"
+                        sx={recommendedSectionSubheadingStyles}
+                    >
+                        Select topics to follow for recommended content
+                    </TypographyScale>
+                    {!!contentItems.length && (
+                        <RecommendedContentSection
+                            content={content}
+                            onSeeTopics={openPersonalizationModal}
+                        />
+                    )}
 
-            {!!contentItems.length && (
-                <RecommendedContentSection
-                    content={content}
-                    onSeeTopics={openPersonalizationModal}
-                />
-            )}
-
-            {!!tags.length && !contentItems.length && (
-                <RecommendedTagSection
-                    tags={tags}
-                    showFooter={showFooter}
-                    onTagsSaved={onTagsSaved}
-                    onTagSelected={(tag: Tag, allSelectedTags: Tag[]) => {
-                        onTagSelected(tag, allSelectedTags);
-                        setSelectedTags(allSelectedTags);
-                    }}
-                />
+                    {!!tags.length && !contentItems.length && (
+                        <RecommendedTagSection
+                            tags={tags}
+                            showFooter={showFooter}
+                            onTagsSaved={onTagsSaved}
+                            onTagSelected={(
+                                tag: Tag,
+                                allSelectedTags: Tag[]
+                            ) => {
+                                onTagSelected(tag, allSelectedTags);
+                                setSelectedTags(allSelectedTags);
+                            }}
+                        />
+                    )}
+                </>
             )}
         </div>
     ) : null;

--- a/src/hooks/personalization/index.ts
+++ b/src/hooks/personalization/index.ts
@@ -27,6 +27,9 @@ const fetcher: Fetcher<{ data: RecommendedContentResponseData }, string> = (
     return fetch(
         (getURLPath('/api/personalized-content') as string) + '?' + query
     ).then(async response => {
+        if (response.status !== 200) {
+            throw Error('Failed to fetch personalized content.');
+        }
         const json = await response.json();
         return json;
     });

--- a/src/hooks/personalization/user-preferences.ts
+++ b/src/hooks/personalization/user-preferences.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { submitPersonalizationSelections } from '../../components/modal/personalization/utils';
 import { Tag } from '../../interfaces/tag';
+import { useNotificationContext } from '../../contexts/notification';
 
 interface UserPreferences {
     followedTags: Array<Tag>;
@@ -11,7 +12,8 @@ interface UserPreferencesHook {
     updateUserPreferences: (prefs: UserPreferences) => Promise<void>;
 }
 const useUserPreferences = (): UserPreferencesHook => {
-    // Can use use context here for notification
+    const { setNotification } = useNotificationContext();
+
     const updateUserPreferences = useCallback(
         async ({ followedTags, emailPreference }: UserPreferences) => {
             try {
@@ -20,10 +22,17 @@ const useUserPreferences = (): UserPreferencesHook => {
                     emailPreference,
                 });
             } catch {
-                alert('Unable to update user prefs.');
+                setNotification({
+                    message:
+                        'Your request could not be completed at this time. Please try again.',
+                    variant: 'WARN',
+                });
                 return;
             }
-            alert('Successfully updated user pref');
+            setNotification({
+                message: 'Successfully saved your preferences',
+                variant: 'SUCCESS',
+            });
         },
         []
     );

--- a/src/hooks/personalization/user-preferences.ts
+++ b/src/hooks/personalization/user-preferences.ts
@@ -34,7 +34,7 @@ const useUserPreferences = (): UserPreferencesHook => {
                 variant: 'SUCCESS',
             });
         },
-        []
+        [setNotification]
     );
 
     return {

--- a/src/hooks/personalization/user-preferences.ts
+++ b/src/hooks/personalization/user-preferences.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+import { submitPersonalizationSelections } from '../../components/modal/personalization/utils';
+import { Tag } from '../../interfaces/tag';
+
+interface UserPreferences {
+    followedTags: Array<Tag>;
+    emailPreference: boolean;
+}
+
+interface UserPreferencesHook {
+    updateUserPreferences: (prefs: UserPreferences) => Promise<void>;
+}
+const useUserPreferences = (): UserPreferencesHook => {
+    // Can use use context here for notification
+    const updateUserPreferences = useCallback(
+        async ({ followedTags, emailPreference }: UserPreferences) => {
+            try {
+                await submitPersonalizationSelections({
+                    followedTags,
+                    emailPreference,
+                });
+            } catch {
+                alert('Unable to update user prefs.');
+                return;
+            }
+            alert('Successfully updated user pref');
+        },
+        []
+    );
+
+    return {
+        updateUserPreferences,
+    };
+};
+
+export default useUserPreferences;

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -72,7 +72,7 @@ export const nextAuthOptions: NextAuthOptions = {
             session.lastName = token.lastName;
             session.email = token.email;
             session.userId = token.sub;
-            console.log('Setting Session');
+            session.failedToFetch = false;
             if (token.sub) {
                 let user;
                 try {

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import NextAuth from 'next-auth';
 import * as Sentry from '@sentry/nextjs';
 import { User } from '../../../interfaces/user-preference';
+import logger from '../../../utils/logger';
 
 async function getUser(userId: string | unknown): Promise<any> {
     const url = `${process.env.BACKEND_URL}/api/user_preferences/${userId}`;
@@ -71,20 +72,36 @@ export const nextAuthOptions: NextAuthOptions = {
             session.lastName = token.lastName;
             session.email = token.email;
             session.userId = token.sub;
+            console.log('Setting Session');
             if (token.sub) {
-                const user = await getUser(token.sub);
+                let user;
+                try {
+                    user = await getUser(token.sub);
+                } catch (err) {
+                    logger.error(err);
+                    session.failedToFetch = true;
+                    return session;
+                }
+
                 if (!user) {
-                    const persisted_user = await persistNewUser({
-                        userId: token.userId,
-                        firstName: token.firstName,
-                        lastName: token.lastName,
-                        email: token.email,
-                        followedTags: [],
-                        lastLogin: null,
-                        emailPreference: false,
-                    } as User);
+                    let persistedUser;
+                    try {
+                        persistedUser = await persistNewUser({
+                            userId: token.userId,
+                            firstName: token.firstName,
+                            lastName: token.lastName,
+                            email: token.email,
+                            followedTags: [],
+                            lastLogin: null,
+                            emailPreference: false,
+                        } as User);
+                    } catch (err) {
+                        logger.error(err);
+                        session.failedToFetch = true;
+                        return session;
+                    }
                     const { followedTags, lastLogin, emailPreference } =
-                        persisted_user;
+                        persistedUser;
                     session.followedTags = followedTags;
                     session.lastLogin = lastLogin;
                     session.emailPreference = emailPreference;

--- a/src/pages/api/personalized-content.ts
+++ b/src/pages/api/personalized-content.ts
@@ -32,11 +32,15 @@ const personalizedContentHandler = async (
                 .status(request.status)
                 .json({ data: response, error: false });
         } else {
+            // Set this to enable refreshing on error.
+            res.setHeader('Cache-Control', 'no-store, max-age=0');
             return res
                 .status(request.status)
                 .json({ data: {}, error: request.statusText });
         }
     } catch (err) {
+        // Set this to enable refreshing on error.
+        res.setHeader('Cache-Control', 'no-store, max-age=0');
         return res.status(400).json({
             error: `Could not get recommended content, ${err}`,
             data: [],

--- a/src/pages/api/userPreferences.ts
+++ b/src/pages/api/userPreferences.ts
@@ -26,11 +26,15 @@ async function userPreferencesHandler(
                 .status(request.status)
                 .json({ data: response, error: false });
         } else {
+            // Set this to enable refreshing on error.
+            res.setHeader('Cache-Control', 'no-store, max-age=0');
             return res
                 .status(request.status)
                 .json({ data: {}, error: request.statusText });
         }
     } catch (err) {
+        // Set this to enable refreshing on error.
+        res.setHeader('Cache-Control', 'no-store, max-age=0');
         return res.status(400).json({
             error: 'Could not update user preferences',
             data: [],

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -84,8 +84,11 @@ const Home: React.FunctionComponent<HomeProps & NextPage> = ({
     const { updateUserPreferences } = useUserPreferences();
     const { status, data } = useSession();
     const followedTags = data?.followedTags || [];
-    const { data: content, isValidating } =
-        usePersonalizedContent(followedTags);
+    const {
+        data: content,
+        isValidating,
+        error: personalizedContentError,
+    } = usePersonalizedContent(followedTags);
 
     return (
         <main
@@ -158,6 +161,7 @@ const Home: React.FunctionComponent<HomeProps & NextPage> = ({
                     followedTags={followedTags}
                     content={content}
                     showFooter
+                    hasContentError={!!personalizedContentError}
                     onTagsSaved={(
                         followedTags: Tag[],
                         emailPreference: boolean

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -161,7 +161,11 @@ const Home: React.FunctionComponent<HomeProps & NextPage> = ({
                     followedTags={followedTags}
                     content={content}
                     showFooter
-                    hasContentError={!!personalizedContentError}
+                    // If there was either an error fetching the profile or the personalizaed content, show error.
+                    hasContentError={
+                        !!personalizedContentError ||
+                        (!!data && !!data.failedToFetch)
+                    }
                     onTagsSaved={(
                         followedTags: Tag[],
                         emailPreference: boolean

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ import getAllMetaInfoRandomPreval from '../service/get-all-meta-info-random.prev
 import { useSession } from 'next-auth/react';
 import { Tag } from '../interfaces/tag';
 import usePersonalizedContent from '../hooks/personalization';
-import { submitPersonalizationSelections } from '../components/modal/personalization/utils';
+import useUserPreferences from '../hooks/personalization/user-preferences';
 
 const getImageSrc = (imageString: string | EThirdPartyLogoVariant) =>
     (
@@ -81,6 +81,7 @@ interface HomeProps {
 const Home: React.FunctionComponent<HomeProps & NextPage> = ({
     recommendedTags,
 }) => {
+    const { updateUserPreferences } = useUserPreferences();
     const { status, data } = useSession();
     const { followedTags } = data || {};
     const { data: content, isValidating } = usePersonalizedContent(
@@ -162,7 +163,7 @@ const Home: React.FunctionComponent<HomeProps & NextPage> = ({
                         emailPreference: boolean
                     ) => {
                         // TODO: Replace with call to user preferences endpoint
-                        submitPersonalizationSelections({
+                        updateUserPreferences({
                             followedTags,
                             emailPreference,
                         });


### PR DESCRIPTION
## Jira Ticket:

[DEVHUB-1703](https://jira.mongodb.org/browse/DEVHUB-1703)

## Description:

- Added a hook (`useUserPreferences`) to utilize the notification context whenever updating preferences.
- Added `failedToFetch` flag on the session object to indicate that we failed to find the user's information.
- Adjust `submitPersonalizationSelections` to throw errors consistently.
- Used these to implement notifications.
- Also adjusted the `Cache-Control` header on personalization endpoints to invalidate the browser cache when sending a bad response. I was having some issues with this and the SWR cache, but it seems to work now.