### PR TITLE
Fix Recommended Tags Section not syncing with Personalization Modal

### DIFF
--- a/src/components/recommended-section/recommended-section.tsx
+++ b/src/components/recommended-section/recommended-section.tsx
@@ -32,7 +32,6 @@ const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
     content,
     showFooter = true,
     hasContentError = false,
-    onTagSelected = () => undefined,
     onTagsSaved = () => undefined,
 }) => {
     const { openModal } = useModalContext();
@@ -50,6 +49,21 @@ const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
             { hideCloseBtn: true }
         );
     }, [openModal, followedTags, selectedTags]);
+
+    const onTagClick = useCallback(
+        (tag: Tag) => {
+            const index = selectedTags.findIndex(
+                selected => selected.slug === tag.slug
+            );
+
+            if (index === -1) {
+                setSelectedTags([...selectedTags, tag]);
+            } else {
+                setSelectedTags(selectedTags.filter((_, i) => i !== index));
+            }
+        },
+        [selectedTags]
+    );
 
     return !!tags.length || !!contentItems.length || !!hasContentError ? (
         <div sx={recommendedSectionStyles}>
@@ -97,15 +111,10 @@ const RecommendedSection: React.FunctionComponent<RecommendedSectionProps> = ({
                     {!!tags.length && !contentItems.length && (
                         <RecommendedTagSection
                             tags={tags}
+                            selectedTags={selectedTags}
                             showFooter={showFooter}
                             onTagsSaved={onTagsSaved}
-                            onTagSelected={(
-                                tag: Tag,
-                                allSelectedTags: Tag[]
-                            ) => {
-                                onTagSelected(tag, allSelectedTags);
-                                setSelectedTags(allSelectedTags);
-                            }}
+                            onTagClick={onTagClick}
                         />
                     )}
                 </>

--- a/src/components/recommended-section/recommended-tag-section.tsx
+++ b/src/components/recommended-section/recommended-tag-section.tsx
@@ -13,39 +13,22 @@ import {
 
 interface RecommendedTagSectionProps {
     tags?: Tag[];
-    onTagsSaved?: (tags: Tag[], digestChecked: boolean) => void;
-    onTagSelected?: (tag: Tag, allSelectedTags: Tag[]) => void;
+    selectedTags?: Tag[];
     showFooter: boolean;
+    onTagsSaved?: (tags: Tag[], digestChecked: boolean) => void;
+    onTagClick?: (tag: Tag) => void;
 }
 
 const RecommendedTagSection: React.FunctionComponent<
     RecommendedTagSectionProps
 > = ({
     tags = [],
-    onTagSelected = () => undefined,
-    onTagsSaved = () => undefined,
+    selectedTags = [],
     showFooter,
+    onTagClick = () => undefined,
+    onTagsSaved = () => undefined,
 }) => {
-    const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
     const [digestChecked, setDigestChecked] = useState(false);
-
-    const topicCardSelected = useCallback(
-        (tag: Tag) => () => {
-            const index = selectedTags.findIndex(
-                selected => selected.slug === tag.slug
-            );
-
-            if (index === -1) {
-                onTagSelected(tag, [...selectedTags, tag]);
-                setSelectedTags([...selectedTags, tag]);
-            } else {
-                const newSelected = [...selectedTags];
-                newSelected.splice(index, 1);
-                setSelectedTags(newSelected);
-            }
-        },
-        [selectedTags, onTagSelected]
-    );
 
     const onSaveButtonClick = useCallback(() => {
         onTagsSaved(selectedTags, digestChecked);
@@ -70,7 +53,7 @@ const RecommendedTagSection: React.FunctionComponent<
                             <TopicCard
                                 title={title}
                                 variant="selectable"
-                                onSelect={topicCardSelected(tag)}
+                                onSelect={() => onTagClick(tag)}
                                 selected={selectedTags.some(
                                     selected => selected.slug === tag.slug
                                 )}


### PR DESCRIPTION
Lifted the selected tags state from the recommended tag section into its parent. Before, the state was being tracked twice, which caused this out-of-sync bug. Also added a test for this case.