### PR TITLE
[DEVHUB-1658] Fix breadcrumb, tertiary nav, follow-topic button when there is no primary tag

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -17,7 +17,7 @@ const getURLs = () =>
             dirent =>
                 `http://localhost:3000/developer/${
                     path.parse(dirent.name).name
-                }`
+                }/`
         );
 module.exports = {
     ci: {

--- a/playwright-tests/pages/[...slug].spec.ts
+++ b/playwright-tests/pages/[...slug].spec.ts
@@ -5,6 +5,8 @@ test.describe.configure({ mode: 'parallel' });
 
 const PAGE_URL =
     '/developer/products/atlas/building-e-commerce-content-catalog-atlas-search/';
+const PAGE_URL_WITHOUT_PRIMARY_TAG =
+    '/developer/podcasts/dwight-merriman-and-lena-smart/';
 
 test('Content page has all components on tutorial', async ({ page }) => {
     await page.goto(PAGE_URL);
@@ -214,3 +216,25 @@ test(
     'Content page visual regression testing',
     runPercy(PAGE_URL, 'Content Page')
 );
+
+test('Content page without primary tag has correct components', async ({
+    page,
+}) => {
+    await page.goto(PAGE_URL_WITHOUT_PRIMARY_TAG);
+
+    // TertiaryNav
+    const tertiaryNavTitle = page.locator('a[href="/developer/podcasts/"] h6');
+    expect(await tertiaryNavTitle.count()).toEqual(1);
+
+    // Breadcrumbs
+    expect(
+        await page
+            .locator('div[data-testid="breadcrumbs"] a:has-text("Podcasts")')
+            .count()
+    ).toEqual(1);
+
+    // No Follow-topic Button
+    expect(
+        await page.locator('div[data-testid="tooltip-body"]').count()
+    ).toEqual(0);
+});

--- a/src/page-templates/content-page/content-page-data.ts
+++ b/src/page-templates/content-page/content-page-data.ts
@@ -12,23 +12,10 @@ import { getContentItemFromSlug } from '../../service/get-content-by-slug';
 import allContentPreval from '../../service/get-all-content.preval';
 import { Tag } from '../../interfaces/tag';
 import { TagType } from '../../types/tag-type';
+import { hasPrimaryTag } from './util';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pluralize = require('pluralize');
-
-const tagsHasPrimaryTag = (tags: Tag[]) => {
-    return tags.some(tag => {
-        return (
-            tag.type === 'L1Product' ||
-            tag.type === 'ProgrammingLanguage' ||
-            tag.type === 'Technology'
-        );
-    });
-};
-
-const hasPrimaryTag = (contentItem: ContentItem) => {
-    return contentItem.tags != null && tagsHasPrimaryTag(contentItem.tags);
-};
 
 const categoryWithoutPrimaryTagToURL: { [key: string]: string } = {
     Podcast: 'https://podcasts.mongodb.com/',

--- a/src/page-templates/content-page/content-page-data.ts
+++ b/src/page-templates/content-page/content-page-data.ts
@@ -16,6 +16,26 @@ import { TagType } from '../../types/tag-type';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pluralize = require('pluralize');
 
+const hasPrimaryTag = (contentItem: ContentItem) => {
+    if (contentItem.tags) {
+        return contentItem.tags.some(
+            item =>
+                item.type === 'L1Product' ||
+                item.type === 'ProgrammingLanguage' ||
+                item.type === 'Technology'
+        );
+    }
+
+    return false;
+};
+
+const categoryWithoutPrimaryTagToURL: { [key: string]: string } = {
+    Podcast: 'https://podcasts.mongodb.com/',
+    Video: 'https://www.mongodb.com/developer/videos/',
+    Event: 'https://www.mongodb.com/developer/events/',
+    'Industry Event': 'https://www.mongodb.com/developer/events/',
+};
+
 export const getContentPageData = async (slug: string[]) => {
     const slugStr = slug.join('/');
     let contentItem: ContentItem | null;
@@ -31,6 +51,7 @@ export const getContentPageData = async (slug: string[]) => {
     }
     if (!contentItem) return null;
 
+    const contentItemHasPrimaryTag = hasPrimaryTag(contentItem);
     const isEventContent = contentItem.collectionType === 'Event';
     let topicSlug = '/' + slug.slice(0, slug.length - 1).join('/');
 
@@ -68,7 +89,9 @@ export const getContentPageData = async (slug: string[]) => {
     const contentTypeSlug = pillCategoryToSlug.get(contentItem.category);
     const topicContentTypeCrumb: Crumb = {
         text: pluralize(contentItem.category),
-        url: `${crumbs[crumbs.length - 1].url}${contentTypeSlug}`,
+        url: contentItemHasPrimaryTag
+            ? `${crumbs[crumbs.length - 1].url}${contentTypeSlug}`
+            : categoryWithoutPrimaryTagToURL[contentItem.category],
     };
 
     crumbs.push(topicContentTypeCrumb);

--- a/src/page-templates/content-page/content-page-data.ts
+++ b/src/page-templates/content-page/content-page-data.ts
@@ -13,15 +13,25 @@ import allContentPreval from '../../service/get-all-content.preval';
 import { Tag } from '../../interfaces/tag';
 import { TagType } from '../../types/tag-type';
 import { hasPrimaryTag } from './util';
+import { PillCategory } from '../../types/pill-category';
+import { getURLPath } from '../../utils/format-url-path';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pluralize = require('pluralize');
 
-const categoryWithoutPrimaryTagToURL: { [key: string]: string } = {
-    Podcast: 'https://podcasts.mongodb.com/',
-    Video: 'https://www.mongodb.com/developer/videos/',
-    Event: 'https://www.mongodb.com/developer/events/',
-    'Industry Event': 'https://www.mongodb.com/developer/events/',
+// Assumes that other category always carries a primary tag
+const categoryWithoutPrimaryTagToURL = (category: PillCategory) => {
+    if (category === 'Podcast') {
+        return 'https://podcasts.mongodb.com/';
+    }
+
+    if (category === 'Video') {
+        return getURLPath('videos');
+    }
+
+    if (category === 'Event' || category === 'Industry Event') {
+        return getURLPath('events');
+    }
 };
 
 export const getContentPageData = async (slug: string[]) => {
@@ -79,7 +89,7 @@ export const getContentPageData = async (slug: string[]) => {
         text: pluralize(contentItem.category),
         url: contentItemHasPrimaryTag
             ? `${crumbs[crumbs.length - 1].url}${contentTypeSlug}`
-            : categoryWithoutPrimaryTagToURL[contentItem.category],
+            : categoryWithoutPrimaryTagToURL(contentItem.category),
     };
     crumbs.push(topicContentTypeCrumb);
 

--- a/src/page-templates/content-page/content-page-data.ts
+++ b/src/page-templates/content-page/content-page-data.ts
@@ -73,9 +73,14 @@ export const getContentPageData = async (slug: string[]) => {
 
     crumbs.push(topicContentTypeCrumb);
 
-    // In the rare event an event has no tags, set tertiary nav to empty to prevent parent and first child titles both displaying "Events"
+    // Events, Podcasts, Videos are not required to have primary tags
+    // In the rare event an item (e.g., event) has no tags, set tertiary nav to empty to prevent parent and first child titles both displaying "Events"
     let tertiaryNavItems =
-        topicSlug === '/events' ? [] : getSideNav(topicSlug, allContentPreval);
+        topicSlug === '/events' ||
+        topicSlug === '/podcasts' ||
+        topicSlug === '/videos'
+            ? []
+            : getSideNav(topicSlug, allContentPreval);
     setURLPathForNavItems(tertiaryNavItems);
 
     const metaInfoForTopic = getMetaInfoForTopic(topicSlug);

--- a/src/page-templates/content-page/content-page-data.ts
+++ b/src/page-templates/content-page/content-page-data.ts
@@ -16,17 +16,16 @@ import { TagType } from '../../types/tag-type';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pluralize = require('pluralize');
 
-const hasPrimaryTag = (contentItem: ContentItem) => {
-    if (contentItem.tags) {
-        return contentItem.tags.some(
-            item =>
-                item.type === 'L1Product' ||
-                item.type === 'ProgrammingLanguage' ||
-                item.type === 'Technology'
-        );
-    }
+const tagsHasPrimaryTag = (tags: Tag[]) => {
+    return tags.some(tag => {
+        tag.type === 'L1Product' ||
+            tag.type === 'ProgrammingLanguage' ||
+            tag.type === 'Technology';
+    });
+};
 
-    return false;
+const hasPrimaryTag = (contentItem: ContentItem) => {
+    return contentItem.tags != null && tagsHasPrimaryTag(contentItem.tags);
 };
 
 const categoryWithoutPrimaryTagToURL: { [key: string]: string } = {
@@ -96,16 +95,11 @@ export const getContentPageData = async (slug: string[]) => {
 
     crumbs.push(topicContentTypeCrumb);
 
-    // Events, Podcasts, Videos are not required to have primary tags
     // In the rare event an item (e.g., event) has no tags, set tertiary nav to empty to prevent parent and first child titles both displaying "Events"
-    const hasNoPrimaryTag =
-        topicSlug === '/events' ||
-        topicSlug === '/podcasts' ||
-        topicSlug === '/videos';
 
-    let tertiaryNavItems = hasNoPrimaryTag
-        ? []
-        : getSideNav(topicSlug, allContentPreval);
+    let tertiaryNavItems = contentItemHasPrimaryTag
+        ? getSideNav(topicSlug, allContentPreval)
+        : [];
     setURLPathForNavItems(tertiaryNavItems);
 
     const metaInfoForTopic = getMetaInfoForTopic(topicSlug);

--- a/src/page-templates/content-page/content-page-data.ts
+++ b/src/page-templates/content-page/content-page-data.ts
@@ -75,12 +75,14 @@ export const getContentPageData = async (slug: string[]) => {
 
     // Events, Podcasts, Videos are not required to have primary tags
     // In the rare event an item (e.g., event) has no tags, set tertiary nav to empty to prevent parent and first child titles both displaying "Events"
-    let tertiaryNavItems =
+    const hasNoPrimaryTag =
         topicSlug === '/events' ||
         topicSlug === '/podcasts' ||
-        topicSlug === '/videos'
-            ? []
-            : getSideNav(topicSlug, allContentPreval);
+        topicSlug === '/videos';
+
+    let tertiaryNavItems = hasNoPrimaryTag
+        ? []
+        : getSideNav(topicSlug, allContentPreval);
     setURLPathForNavItems(tertiaryNavItems);
 
     const metaInfoForTopic = getMetaInfoForTopic(topicSlug);

--- a/src/page-templates/content-page/content-page-data.ts
+++ b/src/page-templates/content-page/content-page-data.ts
@@ -18,9 +18,11 @@ const pluralize = require('pluralize');
 
 const tagsHasPrimaryTag = (tags: Tag[]) => {
     return tags.some(tag => {
-        tag.type === 'L1Product' ||
+        return (
+            tag.type === 'L1Product' ||
             tag.type === 'ProgrammingLanguage' ||
-            tag.type === 'Technology';
+            tag.type === 'Technology'
+        );
     });
 };
 
@@ -92,7 +94,6 @@ export const getContentPageData = async (slug: string[]) => {
             ? `${crumbs[crumbs.length - 1].url}${contentTypeSlug}`
             : categoryWithoutPrimaryTagToURL[contentItem.category],
     };
-
     crumbs.push(topicContentTypeCrumb);
 
     // In the rare event an item (e.g., event) has no tags, set tertiary nav to empty to prevent parent and first child titles both displaying "Events"

--- a/src/page-templates/content-page/content-page-template.tsx
+++ b/src/page-templates/content-page/content-page-template.tsx
@@ -45,7 +45,7 @@ import {
 } from '../../components/modal/feedback/types';
 import { TertiaryNavItem } from '../../components/tertiary-nav/types';
 // utils
-import { normalizeCategory } from './util';
+import { normalizeCategory, isPrimaryTag } from './util';
 import { getCanonicalUrl } from '../../utils/seo';
 import { getURLPath } from '../../utils/format-url-path';
 import { constructDateDisplay } from '../../utils/format-date';
@@ -650,9 +650,9 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                             {
                                 // Render FollowLink only if the topic is followable
                                 // This is for item without primary tag (e.g., Podcast, Video, Event)
-                                topic.type === 'ContentType' ? null : (
+                                isPrimaryTag(topic) ? (
                                     <FollowLink topic={topic} iconsOnly />
-                                )
+                                ) : null
                             }
                         </div>
                         <SideNav currentUrl="#" items={tertiaryNavItems} />

--- a/src/page-templates/content-page/content-page-template.tsx
+++ b/src/page-templates/content-page/content-page-template.tsx
@@ -647,7 +647,13 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                                     {topic.name}
                                 </TypographyScale>
                             </a>
-                            <FollowLink topic={topic} iconsOnly />
+                            {
+                                // Render FollowLink only if the topic is followable
+                                // This is for item without primary tag (e.g., Podcast, Video, Event)
+                                topic.type === 'ContentType' ? null : (
+                                    <FollowLink topic={topic} iconsOnly />
+                                )
+                            }
                         </div>
                         <SideNav currentUrl="#" items={tertiaryNavItems} />
                     </div>

--- a/src/page-templates/content-page/util.ts
+++ b/src/page-templates/content-page/util.ts
@@ -1,4 +1,6 @@
 import { PillCategory } from '../../types/pill-category';
+import { ContentItem } from '../../interfaces/content-item';
+import { Tag } from '../../interfaces/tag';
 
 export function normalizeCategory(category: PillCategory): string {
     if (category === 'News & Announcements') {
@@ -6,4 +8,16 @@ export function normalizeCategory(category: PillCategory): string {
     }
 
     return category.toLowerCase();
+}
+
+export function isPrimaryTag(tag: Tag) {
+    return (
+        tag.type === 'L1Product' ||
+        tag.type === 'ProgrammingLanguage' ||
+        tag.type === 'Technology'
+    );
+}
+
+export function hasPrimaryTag(contentItem: ContentItem) {
+    return contentItem.tags != null && contentItem.tags.some(isPrimaryTag);
 }


### PR DESCRIPTION
## Jira Ticket:

Link to jira ticket [DEVHUB-1111](https://jira.mongodb.org/browse/DEVHUB-1658)

## Description:
Breadcrumbs, Tertiary Nav, and Follow Topic Button can be broken when a `contentItem` has no primary tag (i.e.,`l_1_product`, `programming_language`, `technology`). More details can be found in the Screenshots section below.

1. BreadCrumb: Incorrect topic link can be rendered 
    - Currently Incorrect State ([Podcast Example](https://www.mongodb.com/developer/podcasts/dwight-merriman-and-lena-smart/)): https://www.mongodb.com/developer/topics/podcasts/
    - Corrected State: https://podcasts.mongodb.com/ based on Liz's comment on the [ticket](https://jira.mongodb.org/browse/DEVHUB-1658)
2. Tertiary Nav: Duplicate link may appear
    - Currently Incorrect State ([Podcast Example](https://www.mongodb.com/developer/podcasts/dwight-merriman-and-lena-smart/)): https://www.mongodb.com/developer/topics/podcasts/
    - Corrected State: No more duplicate link per Liz's comment; see the same screenshot below  
3. Follow Topic + Button: 
    - Currently Incorrect State ([Event Example](https://mongodbcom-cdn.staging.corp.mongodb.com/developer/events/that-conf/)): Follow topic link points to an invalid topic (i.e., `event` which is a `contentType`)
    - Corrected State: Do not render the button when the `contentItem` does not have a primary tag

## Related Issue(s) or Dependencies (if applicable):

Please link to the issue(s) or dependencies here

## Checklist: (Check off where applicable)?

-   [x] I have performed a self-review(QA) of my code and reviewed with Design or Product (If Applicable)?
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
Incorrect [Podcast Example](https://www.mongodb.com/developer/podcasts/dwight-merriman-and-lena-smart/) for BreadCrumb and Tertiary Nav

![image](https://user-images.githubusercontent.com/39178325/221894187-2a4a6ef1-5fe3-403b-93cc-f8bb91d426ae.png)

Corrected Podcast Example for BreadCrumb and Tertiary Nav
![image](https://user-images.githubusercontent.com/39178325/221894936-5bda1871-aee8-4af0-b8a5-82c643d01374.png)

Incorrect [Event Example](https://mongodbcom-cdn.staging.corp.mongodb.com/developer/events/that-conf/) for the Follow-Topic + Button
![image](https://user-images.githubusercontent.com/39178325/221897258-14e82b9e-d656-4975-aeaf-53f2edf357fa.png)

Corrected Event Example
![image](https://user-images.githubusercontent.com/39178325/221898744-61a41127-ddf7-485c-abbf-ff4ab1a52f24.png)


