### PR TITLE
[DEVHUB-1695] Add query parameter to hide menus for PathFactory.

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -13,6 +13,7 @@ import { useModalContext } from '../contexts/modal';
 import { PaginatedPersonalizationModal } from './modal/personalization';
 import getSignInURL from '../utils/get-sign-in-url';
 import useUserPreferences from '../hooks/personalization/user-preferences';
+import { Globals as FloraGlobals } from '@mdb/flora'; // Need this to load fonts when UnifiedNav isn't present.
 
 const navStyles: ThemeUICSSObject = {
     zIndex: '9999',
@@ -26,11 +27,13 @@ const navStyles: ThemeUICSSObject = {
 };
 interface LayoutProps {
     pagePath?: string | null;
+    isPathFactory?: boolean;
 }
 
 const Layout: React.FunctionComponent<LayoutProps> = ({
     children,
     pagePath,
+    isPathFactory,
 }) => {
     const { updateUserPreferences } = useUserPreferences();
     const { hasOverlay } = useContext(OverlayContext);
@@ -69,19 +72,25 @@ const Layout: React.FunctionComponent<LayoutProps> = ({
                     ${globalStyles(!!hasOverlay || !!hasModalOpen)}
                 `}
             />
-            <div sx={navStyles}>
-                <UnifiedNav
-                    position="static"
-                    floraTheme="default"
-                    property={{ name: 'DEVHUB', searchParams: [] }}
-                    hideTryFree={!!session}
-                    hideSignIn={!!session}
-                    signInUrl={signInUrl}
-                />
-            </div>
-            <SecondaryNav />
+            <FloraGlobals />
+            {!isPathFactory && (
+                <>
+                    <div sx={navStyles}>
+                        <UnifiedNav
+                            position="static"
+                            floraTheme="default"
+                            property={{ name: 'DEVHUB', searchParams: [] }}
+                            hideTryFree={!!session}
+                            hideSignIn={!!session}
+                            signInUrl={signInUrl}
+                        />
+                    </div>
+                    <SecondaryNav />
+                </>
+            )}
+
             <Main>{children}</Main>
-            <UnifiedFooter hideLocale />
+            {!isPathFactory && <UnifiedFooter hideLocale />}
         </div>
     );
 };

--- a/src/page-templates/content-page/content-page-template.tsx
+++ b/src/page-templates/content-page/content-page-template.tsx
@@ -78,6 +78,7 @@ interface ContentPageProps {
     tertiaryNavItems: TertiaryNavItem[];
     relatedContent: ContentItem[];
     previewMode?: boolean;
+    isPathFactory?: boolean;
 }
 
 const parseUndefinedValue = (description: string | undefined): string =>
@@ -116,6 +117,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
         registrationLink,
         virtualLinkText,
     },
+    isPathFactory,
 }) => {
     const router = useRouter();
     const { asPath } = router;
@@ -153,7 +155,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
     const displayTitle = (
         <TypographyScale
             customElement="h1"
-            variant="heading2"
+            variant={`heading${isPathFactory ? '5' : '2'}`}
             sx={{ marginBottom: ['inc20', null, null, 'inc30'] }}
         >
             {title}
@@ -252,7 +254,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
     );
 
     const contentFooter = (
-        <div sx={styles.footer}>
+        <div sx={styles.getFooterStyles(isPathFactory)}>
             <div>
                 <HorizontalRule />
                 {!previewMode && (
@@ -315,7 +317,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
 
     const VideoOrPodcastContent = () => (
         <>
-            <div sx={styles.section}>
+            <div sx={styles.getSectionStyles(isPathFactory)}>
                 {displayTitle}
                 <div sx={styles.vidOrPodHeaderGrid}>
                     <TypographyScale
@@ -335,7 +337,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                     {getSocialButtons(true)}
                 </div>
             </div>
-            <div sx={styles.section}>
+            <div sx={styles.getSectionStyles(isPathFactory)}>
                 <div sx={styles.image}>
                     {category === 'Video' ? (
                         <VideoEmbed
@@ -350,7 +352,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                 </div>
                 {!previewMode && ratingSection}
             </div>
-            <div sx={styles.bodySection}>
+            <div sx={styles.getBodySectionStyles(isPathFactory)}>
                 <>
                     <TypographyScale
                         variant="body1"
@@ -461,11 +463,11 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
 
         return (
             <>
-                <div sx={styles.section}>
+                <div sx={styles.getSectionStyles(isPathFactory)}>
                     {displayTitle}
                     {isIndustryEvent ? eventHeader : defaultHeader}
                 </div>
-                <div sx={styles.section}>
+                <div sx={styles.getSectionStyles(isPathFactory)}>
                     {displayHeaderImage && (
                         <div sx={styles.image}>
                             <Image
@@ -505,7 +507,7 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                         />
                     )}
                 </div>
-                <div sx={styles.bodySection}>
+                <div sx={styles.getBodySectionStyles(isPathFactory)}>
                     <DocumentBody content={contentAst} />
                     {isIndustryEvent && authors.length > 0 && (
                         <>
@@ -637,27 +639,41 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
             />
             <div sx={styles.wrapper}>
                 <GridLayout sx={{ rowGap: 0 }}>
-                    <div sx={sideNavStyles(5)}>
-                        <div sx={titleFollowTopicStyles}>
-                            <a href={getURLPath(topic.slug)}>
-                                <TypographyScale
-                                    variant="heading6"
-                                    sx={sideNavTitleStyles}
-                                >
-                                    {topic.name}
-                                </TypographyScale>
-                            </a>
-                            {
-                                // Render FollowLink only if the topic is followable
-                                // This is for item without primary tag (e.g., Podcast, Video, Event)
-                                isPrimaryTag(topic) ? (
-                                    <FollowLink topic={topic} iconsOnly />
-                                ) : null
-                            }
-                        </div>
-                        <SideNav currentUrl="#" items={tertiaryNavItems} />
-                    </div>
-                    <Breadcrumbs crumbs={crumbs} sx={styles.breadcrumbs} />
+                    {!isPathFactory && (
+                        <>
+                            <div sx={sideNavStyles(5)}>
+                                <div sx={titleFollowTopicStyles}>
+                                    <a href={getURLPath(topic.slug)}>
+                                        <TypographyScale
+                                            variant="heading6"
+                                            sx={sideNavTitleStyles}
+                                        >
+                                            {topic.name}
+                                        </TypographyScale>
+                                    </a>
+                                    {
+                                        // Render FollowLink only if the topic is followable
+                                        // This is for item without primary tag (e.g., Podcast, Video, Event)
+                                        isPrimaryTag(topic) ? (
+                                            <FollowLink
+                                                topic={topic}
+                                                iconsOnly
+                                            />
+                                        ) : null
+                                    }
+                                </div>
+                                <SideNav
+                                    currentUrl="#"
+                                    items={tertiaryNavItems}
+                                />
+                            </div>
+
+                            <Breadcrumbs
+                                crumbs={crumbs}
+                                sx={styles.breadcrumbs}
+                            />
+                        </>
+                    )}
                     {isVideoOrPodcastContent ? (
                         <VideoOrPodcastContent />
                     ) : (

--- a/src/page-templates/content-page/styles.ts
+++ b/src/page-templates/content-page/styles.ts
@@ -81,7 +81,7 @@ const getSectionStyles = (
         null,
         'span 8',
         '1 /span 9',
-        isPathFactory ? '1 /span 9' : '4 /span 6',
+        isPathFactory ? null : '4 /span 6',
     ],
 });
 const getBodySectionStyles = (

--- a/src/page-templates/content-page/styles.ts
+++ b/src/page-templates/content-page/styles.ts
@@ -72,22 +72,33 @@ const breadcrumbs = {
     gridColumn: ['span 6', null, 'span 8', 'span 12', 'span 9'],
 };
 
-const section = {
+const getSectionStyles = (
+    isPathFactory: boolean | undefined
+): ThemeUICSSObject => ({
     maxWidth: '100%', // patches a Codemirror bug on FF https://github.com/codemirror/CodeMirror/issues/4142.
-    gridColumn: ['span 6', null, 'span 8', '1 /span 9', '4 /span 6'],
-};
-
-const bodySection = {
-    ...section,
+    gridColumn: [
+        'span 6',
+        null,
+        'span 8',
+        '1 /span 9',
+        isPathFactory ? '1 /span 9' : '4 /span 6',
+    ],
+});
+const getBodySectionStyles = (
+    isPathFactory: boolean | undefined
+): ThemeUICSSObject => ({
+    ...getSectionStyles(isPathFactory),
     my: ['section20', null, 'section30', 'section40'],
-};
+});
 
-const footer: ThemeUICSSObject = {
+const getFooterStyles = (
+    isPathFactory: boolean | undefined
+): ThemeUICSSObject => ({
     display: 'flex',
     flexDirection: 'column',
     gap: ['section30', null, 'section40', 'section50'],
-    ...section,
-};
+    ...getSectionStyles(isPathFactory),
+});
 
 const footerActions: ThemeUICSSObject = {
     display: 'flex',
@@ -137,12 +148,12 @@ const vidOrPodContent: ThemeUICSSObject = {
 
 const styles = {
     image,
-    footer,
+    getFooterStyles,
     floatingMenu,
     wrapper,
-    section,
+    getSectionStyles,
     ratingSection,
-    bodySection,
+    getBodySectionStyles,
     defaultHeaderGrid,
     vidOrPodHeaderGrid,
     breadcrumbs,
@@ -152,5 +163,7 @@ const styles = {
     footerActions,
     eventHeaderGrid,
 };
+
+export { getSectionStyles, getBodySectionStyles, getFooterStyles };
 
 export default styles;

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -18,15 +18,22 @@ import TopicPageTemplate from '../page-templates/topic-page/topic-page-template'
 interface ContentPageProps {
     pageType: PageType;
     pageData: any;
+    isPathFactory?: boolean;
 }
 
 const DynamicContentPage: NextPage<ContentPageProps> = ({
     pageType,
     pageData,
+    isPathFactory,
 }) => {
     switch (pageType) {
         case PageType.Content:
-            return <ContentPageTemplate {...pageData} />;
+            return (
+                <ContentPageTemplate
+                    isPathFactory={isPathFactory}
+                    {...pageData}
+                />
+            );
         case PageType.Topic:
             return <TopicPageTemplate {...pageData} />;
         case PageType.TopicContentType:
@@ -44,7 +51,7 @@ export const getServerSideProps: GetServerSideProps = async (
     const { query } = context;
     const { slug } = query as PageParams;
 
-    const dynamicPageType: DynamicPageType = await pageTypeFactory(slug);
+    const dynamicPageType: DynamicPageType = pageTypeFactory(slug);
     const {
         pageType,
         pageParams,
@@ -52,6 +59,7 @@ export const getServerSideProps: GetServerSideProps = async (
     let data: any | null = {};
 
     let pageNumber: number;
+    let isPathFactory = false;
     switch (pageType) {
         case PageType.Content:
             // cache content only for 5 minutes
@@ -61,6 +69,10 @@ export const getServerSideProps: GetServerSideProps = async (
             );
 
             data = await getContentPageData(slug);
+            // PathFactory embeds content pages, and would like certain elements to be removed via query param.
+            if (query.hideMenu === '1') {
+                isPathFactory = true;
+            }
             break;
         case PageType.Topic:
             pageNumber = parsePageNumber(query.page);
@@ -109,6 +121,7 @@ export const getServerSideProps: GetServerSideProps = async (
         props: {
             pageData: data,
             pageType: pageType,
+            isPathFactory,
         },
     };
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -22,10 +22,8 @@ import {
     shouldDefineDefaultCanonical,
 } from '../utils/seo';
 import { customCache } from '../utils/emotion';
-import { pageTypeFactory } from '../utils/page-type-factory';
 
 import '../../mocks/run-msw';
-import { PageType } from '../types/page-type';
 
 interface CustomProps {
     session?: Session;
@@ -33,14 +31,11 @@ interface CustomProps {
 
 function MyApp({ Component, pageProps, session }: AppProps & CustomProps) {
     const router = useRouter();
-    const { slug, hideMenu } = router.query;
+    const { hideMenu } = router.query;
     // PathFactory embeds content pages, and would like certain elements to be removed via query param.
     let isPathFactory = false;
-    if (hideMenu === '1' && slug && Array.isArray(slug)) {
-        const { pageType } = pageTypeFactory(slug);
-        if (pageType === PageType.Content) {
-            isPathFactory = true;
-        }
+    if (hideMenu === '1') {
+        isPathFactory = true;
     }
     const { publicRuntimeConfig } = getConfig();
     const { absoluteBasePath } = publicRuntimeConfig;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -22,8 +22,10 @@ import {
     shouldDefineDefaultCanonical,
 } from '../utils/seo';
 import { customCache } from '../utils/emotion';
+import { pageTypeFactory } from '../utils/page-type-factory';
 
 import '../../mocks/run-msw';
+import { PageType } from '../types/page-type';
 
 interface CustomProps {
     session?: Session;
@@ -31,6 +33,15 @@ interface CustomProps {
 
 function MyApp({ Component, pageProps, session }: AppProps & CustomProps) {
     const router = useRouter();
+    const { slug, hideMenu } = router.query;
+    // PathFactory embeds content pages, and would like certain elements to be removed via query param.
+    let isPathFactory = false;
+    if (hideMenu === '1' && slug && Array.isArray(slug)) {
+        const { pageType } = pageTypeFactory(slug);
+        if (pageType === PageType.Content) {
+            isPathFactory = true;
+        }
+    }
     const { publicRuntimeConfig } = getConfig();
     const { absoluteBasePath } = publicRuntimeConfig;
     const { asPath, route } = router;
@@ -65,7 +76,10 @@ function MyApp({ Component, pageProps, session }: AppProps & CustomProps) {
                         <NotificationsProvider>
                             <ModalProvider>
                                 <OverlayProvider>
-                                    <Layout pagePath={pagePath}>
+                                    <Layout
+                                        pagePath={pagePath}
+                                        isPathFactory={isPathFactory}
+                                    >
                                         <ErrorBoundary>
                                             <ModalRoot />
                                             <NotificationsContainer />

--- a/src/service/get-topic-paths.ts
+++ b/src/service/get-topic-paths.ts
@@ -5,7 +5,7 @@ import { getSideNav } from '../service/get-side-nav';
 import { TertiaryNavItem } from '../components/tertiary-nav/types';
 import { L1L2_TOPIC_PAGE_TYPES } from '../data/constants';
 
-export const getTopicPagePathMappings = async () => {
+export const getTopicPagePathMappings = () => {
     const distinctSlugs = distinctTags
         .filter(tag => L1L2_TOPIC_PAGE_TYPES.includes(tag.type))
         .map(tag => tag.slug);
@@ -27,10 +27,7 @@ export const getTopicPagePathMappings = async () => {
             fullSlug: fullSlug,
         };
 
-        const tertiaryNavItems = await getSideNav(
-            distinctSlug,
-            allContentPreval
-        );
+        const tertiaryNavItems = getSideNav(distinctSlug, allContentPreval);
 
         tertiaryNavItems.forEach((item: TertiaryNavItem) => {
             const parsedItemUrl = item.url.startsWith('/')

--- a/src/utils/page-type-factory.ts
+++ b/src/utils/page-type-factory.ts
@@ -2,15 +2,12 @@ import { getTopicPagePathMappings } from '../service/get-topic-paths';
 import { PageType } from '../types/page-type';
 import { DynamicPageType } from '../types/page-type-factory';
 
-export const pageTypeFactory = async (
-    slug: string[]
-): Promise<DynamicPageType> => {
+export const pageTypeFactory = (slug: string[]): DynamicPageType => {
     const slugStr = slug.join('/');
     let pageType = null;
     let pageParams = null;
 
-    const { topicPaths, topicContentTypePaths } =
-        await getTopicPagePathMappings();
+    const { topicPaths, topicContentTypePaths } = getTopicPagePathMappings();
 
     if (slugStr in topicPaths) {
         pageType = PageType.Topic;


### PR DESCRIPTION
## Jira Ticket:

[DEVHUB-1695](https://jira.mongodb.org/browse/DEVHUB-1695)

## Description:

This follows the same pattern that the blog uses for PathFactory. Compare: https://www.mongodb.com/blog/post/mongodb-named-leader-2022-gartner-magic-quadrant-cloud-database-management-systems to
https://www.mongodb.com/blog/post/mongodb-named-leader-2022-gartner-magic-quadrant-cloud-database-management-systems?hideMenu=1

I also removed some unnecessary async/await statements around `getTopicPagePathMappings`.