### PR TITLE
[DEVHUB-1696] Set CSP headers to allow embedding from *.mongodb.com.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
         "@typescript-eslint/no-unused-vars": [
             "error",
             { "ignoreRestSiblings": true }
-        ]
+        ],
+        "@typescript-eslint/no-var-requires": "off"
     },
     "ignorePatterns": ["mocks/data/*.js"]
 }

--- a/next.config.js
+++ b/next.config.js
@@ -99,6 +99,10 @@ const configVals = {
                         key: 'X-Frame-Options',
                         value: 'SAMEORIGIN',
                     },
+                    {
+                        key: 'Content-Security-Policy',
+                        value: "frame-ancestors 'self' https://*.mongodb.com",
+                    },
                 ],
             },
             {
@@ -115,6 +119,10 @@ const configVals = {
                     {
                         key: 'X-Frame-Options',
                         value: 'SAMEORIGIN',
+                    },
+                    {
+                        key: 'Content-Security-Policy',
+                        value: "frame-ancestors 'self' https://*.mongodb.com",
                     },
                 ],
             },


### PR DESCRIPTION
## Jira Ticket:
[DEVHUB-1696](https://jira.mongodb.org/browse/DEVHUB-1696)

## Description:

Followup to https://github.com/mongodb/devcenter/pull/475.

PathFactory could not embed our content on https://mongodbcom.website.prod.corp.mongodb.com because we have the `X-Frame-Options` header set to `SAMEORIGIN` for all pages. I added the `Content-Security-Policy` header's `frame-ancestors` attribute, which adds more control to embedding behavior. I set it to allow embedding from all subdomains of mongodb.com, as well as from the same origin.

Also disabled an ESLint rule affecting the next.config.js file.