### PR TITLE
[DEVHUB-1744] Integrate Podcasts from ContentStack

### DIFF
--- a/src/api-requests/get-all-meta-info.ts
+++ b/src/api-requests/get-all-meta-info.ts
@@ -2,6 +2,7 @@ import { UnderlyingClient } from '../types/client-factory';
 import { ApolloQueryResult, gql } from '@apollo/client';
 import { MetaInfoResponse } from '../interfaces/meta-info';
 import { isStrapiClient } from '../utils/client-factory';
+import { TagType } from '../types/tag-type';
 
 type metaInfoType =
     | 'l1Products'
@@ -11,14 +12,6 @@ type metaInfoType =
     | 'expertiseLevels'
     | 'contentTypes';
 
-type __typename =
-    | 'L1Product'
-    | 'L2Product'
-    | 'ProgrammingLanguage'
-    | 'Technology'
-    | 'ExpertiseLevel'
-    | 'ContentType';
-
 // NOTE: Failed to set type for data
 /**
  * Adapt ContentStack' returned data into format consistent with Strapi
@@ -27,7 +20,7 @@ const dataAdapter = (
     isStrapiClient: boolean,
     metaInfoType: metaInfoType,
     data: any,
-    __typename: __typename
+    __typename: TagType
 ) => {
     let adaptedData = data[metaInfoType];
 

--- a/src/api-requests/get-all-meta-info.ts
+++ b/src/api-requests/get-all-meta-info.ts
@@ -1,11 +1,77 @@
 import { UnderlyingClient } from '../types/client-factory';
 import { ApolloQueryResult, gql } from '@apollo/client';
 import { MetaInfoResponse } from '../interfaces/meta-info';
+import { isStrapiClient } from '../utils/client-factory';
+
+type metaInfoType =
+    | 'l1Products'
+    | 'l2Products'
+    | 'programmingLanguages'
+    | 'technologies'
+    | 'expertiseLevels'
+    | 'contentTypes';
+
+type __typename =
+    | 'L1Product'
+    | 'L2Product'
+    | 'ProgrammingLanguage'
+    | 'Technology'
+    | 'ExpertiseLevel'
+    | 'ContentType';
+
+// NOTE: Failed to set type for data
+/**
+ * Adapt ContentStack' returned data into format consistent with Strapi
+ */
+const dataAdapter = (
+    isStrapiClient: boolean,
+    metaInfoType: metaInfoType,
+    data: any,
+    __typename: __typename
+) => {
+    let adaptedData = data[metaInfoType];
+
+    if (isStrapiClient) {
+        return adaptedData;
+    }
+
+    adaptedData = adaptedData.items;
+
+    if (metaInfoType === 'l2Products') {
+        return adaptedData.map((d: any) => ({
+            ...d,
+            __typename,
+            l1_product: {
+                l_1_product: { name: d.l1_product.edges[0].node.name },
+            },
+        }));
+    }
+
+    return adaptedData.map((d: any) => ({
+        ...d,
+        __typename,
+    }));
+};
 
 export const getAllL1ProductsMetaInfo = async (
-    client: UnderlyingClient<'ApolloREST'>
+    client: UnderlyingClient<'ApolloREST'> | UnderlyingClient<'ApolloGraphQL'>
 ): Promise<MetaInfoResponse[]> => {
-    const query = gql`
+    const cs_query = gql`
+        query L1Products {
+            l1Products: all_l1_products {
+                items {
+                    name: title
+                    description
+                    slug: calculated_slug
+                    secondary_cta
+                    primary_cta
+                    documentation_link
+                }
+            }
+        }
+    `;
+
+    const strapi_query = gql`
         query L1Products {
             l1Products @rest(type: "L1Product", path: "/l-1-products") {
                 name
@@ -17,16 +83,51 @@ export const getAllL1ProductsMetaInfo = async (
             }
         }
     `;
+
+    const isStrapi = isStrapiClient(client);
+    const query = isStrapi ? strapi_query : cs_query;
+
     const { data }: ApolloQueryResult<{ l1Products: MetaInfoResponse[] }> =
         await client.query({ query });
 
-    return data.l1Products;
+    const adaptedData = dataAdapter(
+        isStrapi,
+        'l1Products',
+        data,
+        'L1Product'
+    ) as MetaInfoResponse[];
+
+    return adaptedData;
 };
 
 export const getAllL2ProductsMetaInfo = async (
-    client: UnderlyingClient<'ApolloREST'>
+    client: UnderlyingClient<'ApolloREST'> | UnderlyingClient<'ApolloGraphQL'>
 ): Promise<MetaInfoResponse[]> => {
-    const query = gql`
+    const cs_query = gql`
+        query L2_products {
+            l2Products: all_l2_products {
+                items {
+                    name: title
+                    description
+                    slug: calculated_slug
+                    primary_cta
+                    secondary_cta
+                    documentation_link
+                    l1_product: l1_productConnection {
+                        edges {
+                            node {
+                                ... on L1Products {
+                                    name: title
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    `;
+
+    const strapi_query = gql`
         query L2Products {
             l2Products @rest(type: "L2Product", path: "/l-2-products") {
                 name
@@ -43,16 +144,42 @@ export const getAllL2ProductsMetaInfo = async (
             }
         }
     `;
+
+    const isStrapi = isStrapiClient(client);
+    const query = isStrapi ? strapi_query : cs_query;
+
     const { data }: ApolloQueryResult<{ l2Products: MetaInfoResponse[] }> =
         await client.query({ query });
 
-    return data.l2Products;
+    const adaptedData = dataAdapter(
+        isStrapi,
+        'l2Products',
+        data,
+        'L2Product'
+    ) as MetaInfoResponse[];
+
+    return adaptedData;
 };
 
 export const getAllProgrammingLanguagesMetaInfo = async (
     client: UnderlyingClient<'ApolloREST'>
 ): Promise<MetaInfoResponse[]> => {
-    const query = gql`
+    const cs_query = gql`
+        query ProgrammingLanguages {
+            programmingLanguages: all_programming_languages {
+                items {
+                    name: title
+                    description
+                    slug: calculated_slug
+                    secondary_cta
+                    primary_cta
+                    documentation_link
+                }
+            }
+        }
+    `;
+
+    const strapi_query = gql`
         query ProgrammingLanguages {
             programmingLanguages
                 @rest(
@@ -68,12 +195,23 @@ export const getAllProgrammingLanguagesMetaInfo = async (
             }
         }
     `;
+
+    const isStrapi = isStrapiClient(client);
+    const query = isStrapi ? strapi_query : cs_query;
+
     const {
         data,
     }: ApolloQueryResult<{ programmingLanguages: MetaInfoResponse[] }> =
         await client.query({ query });
 
-    return data.programmingLanguages;
+    const adaptedData = dataAdapter(
+        isStrapi,
+        'programmingLanguages',
+        data,
+        'ProgrammingLanguage'
+    ) as MetaInfoResponse[];
+
+    return adaptedData;
 };
 
 /*
@@ -83,7 +221,22 @@ export const getAllProgrammingLanguagesMetaInfo = async (
 export const getAllTechnologiesMetaInfo = async (
     client: UnderlyingClient<'ApolloREST'>
 ): Promise<MetaInfoResponse[]> => {
-    const query = gql`
+    const cs_query = gql`
+        query Technologies {
+            technologies: all_technologies {
+                items {
+                    name: title
+                    description
+                    slug: calculated_slug
+                    secondary_cta
+                    primary_cta
+                    documentation_link
+                }
+            }
+        }
+    `;
+
+    const strapi_query = gql`
         query Technologies {
             technologies @rest(type: "Technology", path: "/technologies") {
                 name
@@ -95,16 +248,41 @@ export const getAllTechnologiesMetaInfo = async (
             }
         }
     `;
+
+    const isStrapi = isStrapiClient(client);
+    const query = isStrapi ? strapi_query : cs_query;
+
     const { data }: ApolloQueryResult<{ technologies: MetaInfoResponse[] }> =
         await client.query({ query });
 
-    return data.technologies;
+    const adaptedData = dataAdapter(
+        isStrapi,
+        'technologies',
+        data,
+        'Technology'
+    ) as MetaInfoResponse[];
+
+    return adaptedData;
 };
 
 export const getAllExpertiseLevelsMetaInfo = async (
     client: UnderlyingClient<'ApolloREST'>
 ): Promise<MetaInfoResponse[]> => {
-    const query = gql`
+    const cs_query = gql`
+        query ExpertiseLevels {
+            expertiseLevels: all_levels {
+                items {
+                    name: title
+                    description
+                    slug: calculated_slug
+                    secondary_cta
+                    primary_cta
+                }
+            }
+        }
+    `;
+
+    const strapi_query = gql`
         query ExpertiseLevels {
             expertiseLevels @rest(type: "ExpertiseLevel", path: "/levels") {
                 name: level
@@ -115,16 +293,41 @@ export const getAllExpertiseLevelsMetaInfo = async (
             }
         }
     `;
+
+    const isStrapi = isStrapiClient(client);
+    const query = isStrapi ? strapi_query : cs_query;
+
     const { data }: ApolloQueryResult<{ expertiseLevels: MetaInfoResponse[] }> =
         await client.query({ query });
 
-    return data.expertiseLevels;
+    const adaptedData = dataAdapter(
+        isStrapi,
+        'expertiseLevels',
+        data,
+        'ExpertiseLevel'
+    ) as MetaInfoResponse[];
+
+    return adaptedData;
 };
 
 export const getAllContentTypesMetaInfo = async (
     client: UnderlyingClient<'ApolloREST'>
 ): Promise<MetaInfoResponse[]> => {
-    const query = gql`
+    const cs_query = gql`
+        query ContentTypes {
+            contentTypes: all_content_types {
+                items {
+                    name: title
+                    description
+                    slug: calculated_slug
+                    secondary_cta
+                    primary_cta
+                }
+            }
+        }
+    `;
+
+    const strapi_query = gql`
         query ContentTypes {
             contentTypes @rest(type: "ContentType", path: "/content-types") {
                 name: content_type
@@ -135,8 +338,19 @@ export const getAllContentTypesMetaInfo = async (
             }
         }
     `;
+
+    const isStrapi = isStrapiClient(client);
+    const query = isStrapi ? strapi_query : cs_query;
+
     const { data }: ApolloQueryResult<{ contentTypes: MetaInfoResponse[] }> =
         await client.query({ query });
 
-    return data.contentTypes;
+    const adaptedData = dataAdapter(
+        isStrapi,
+        'contentTypes',
+        data,
+        'ContentType'
+    ) as MetaInfoResponse[];
+
+    return adaptedData;
 };

--- a/src/api-requests/get-podcasts.ts
+++ b/src/api-requests/get-podcasts.ts
@@ -2,6 +2,8 @@ import { ApolloQueryResult, gql } from '@apollo/client';
 
 import { UnderlyingClient } from '../types/client-factory';
 import { Podcast } from '../interfaces/podcast';
+import { isStrapiClient } from '../utils/client-factory';
+import { extractFieldsFromNode, getSEO, insertTypename } from './utils';
 
 const podcastFields = `
     description
@@ -62,14 +64,280 @@ const podcastFields = `
     }
 `;
 
+const cs_query_all = gql`
+    query Podcasts {
+        podcasts: all_podcasts {
+            items {
+                description
+                publishDate: original_publish_date
+                title
+                slug
+                podcastFileUrl: podcast_file_url
+                thumbnailUrl: thumbnail_url
+                casted_slug
+                l1Product: l1_productConnection {
+                    edges {
+                        node {
+                            ... on L1Products {
+                                name: title
+                                calculatedSlug: calculated_slug
+                            }
+                        }
+                    }
+                }
+                l2Product: l2_productConnection {
+                    edges {
+                        node {
+                            ... on L2Products {
+                                name: title
+                                calculatedSlug: calculated_slug
+                            }
+                        }
+                    }
+                }
+                programmingLanguage: programming_languagesConnection {
+                    edges {
+                        node {
+                            ... on ProgrammingLanguages {
+                                name: title
+                                calculatedSlug: calculated_slug
+                            }
+                        }
+                    }
+                }
+                technology: technologiesConnection {
+                    edges {
+                        node {
+                            ... on Technologies {
+                                title
+                                calculated_slug
+                            }
+                        }
+                    }
+                }
+                otherTags: other_tags {
+                    spokenLanguage: spoken_languageConnection {
+                        edges {
+                            node {
+                                ... on SpokenLanguages {
+                                    name: title
+                                    calculatedSlug: calculated_slug
+                                }
+                            }
+                        }
+                    }
+                    expertiseLevel: expertise_levelConnection {
+                        edges {
+                            node {
+                                ... on Levels {
+                                    name: title
+                                    calculatedSlug: calculated_slug
+                                }
+                            }
+                        }
+                    }
+                    authorType: author_typeConnection {
+                        edges {
+                            node {
+                                ... on AuthorTypes {
+                                    name: title
+                                    calculatedSlug: calculated_slug
+                                }
+                            }
+                        }
+                    }
+                }
+                seo {
+                    canonical_url
+                    meta_description
+                    og_description
+                    og_image: og_imageConnection {
+                        edges {
+                            node {
+                                url
+                            }
+                        }
+                    }
+                    twitter_card
+                    twitter_creator
+                    twitter_description
+                    twitter_image: twitter_imageConnection {
+                        edges {
+                            node {
+                                url
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`;
+
+const cs_query_by_slug = gql`
+    query Podcasts($slug: String!) {
+        podcasts: all_podcasts(where: { slug: $slug }) {
+            items {
+                description
+                publishDate: original_publish_date
+                title
+                slug
+                podcastFileUrl: podcast_file_url
+                thumbnailUrl: thumbnail_url
+                casted_slug
+                l1Product: l1_productConnection {
+                    edges {
+                        node {
+                            ... on L1Products {
+                                name: title
+                                calculatedSlug: calculated_slug
+                            }
+                        }
+                    }
+                }
+                l2Product: l2_productConnection {
+                    edges {
+                        node {
+                            ... on L2Products {
+                                name: title
+                                calculatedSlug: calculated_slug
+                            }
+                        }
+                    }
+                }
+                programmingLanguage: programming_languagesConnection {
+                    edges {
+                        node {
+                            ... on ProgrammingLanguages {
+                                name: title
+                                calculatedSlug: calculated_slug
+                            }
+                        }
+                    }
+                }
+                technology: technologiesConnection {
+                    edges {
+                        node {
+                            ... on Technologies {
+                                title
+                                calculated_slug
+                            }
+                        }
+                    }
+                }
+                otherTags: other_tags {
+                    spokenLanguage: spoken_languageConnection {
+                        edges {
+                            node {
+                                ... on SpokenLanguages {
+                                    name: title
+                                    calculatedSlug: calculated_slug
+                                }
+                            }
+                        }
+                    }
+                    expertiseLevel: expertise_levelConnection {
+                        edges {
+                            node {
+                                ... on Levels {
+                                    name: title
+                                    calculatedSlug: calculated_slug
+                                }
+                            }
+                        }
+                    }
+                    authorType: author_typeConnection {
+                        edges {
+                            node {
+                                ... on AuthorTypes {
+                                    name: title
+                                    calculatedSlug: calculated_slug
+                                }
+                            }
+                        }
+                    }
+                }
+                seo {
+                    canonical_url
+                    meta_description
+                    og_description
+                    og_image: og_imageConnection {
+                        edges {
+                            node {
+                                url
+                            }
+                        }
+                    }
+                    twitter_card
+                    twitter_creator
+                    twitter_description
+                    twitter_image: twitter_imageConnection {
+                        edges {
+                            node {
+                                url
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`;
+
+/**
+ * Ensure CS response is compatible with original Strapi format
+ */
+const formatResponse = (
+    isStrapiClient: boolean,
+    data: any,
+    allMode: boolean
+) => {
+    if (isStrapiClient && allMode) {
+        return data.podcasts;
+    }
+
+    if (isStrapiClient && !allMode) {
+        return data.podcasts.length > 0 ? data.podcasts[0] : null;
+    }
+
+    if (data.podcasts.items.length === 0) {
+        return [];
+    }
+
+    let podcasts = data.podcasts.items;
+
+    podcasts = podcasts.map((podcast: { [key: string]: any }) => ({
+        ...podcast,
+        l1Product: extractFieldsFromNode(podcast.l1Product, [
+            'name',
+            'calculatedSlug',
+        ]),
+        l2Product: extractFieldsFromNode(podcast.l2Product, [
+            'name',
+            'calculatedSlug',
+        ]),
+        programmingLanguage: extractFieldsFromNode(
+            podcast.programmingLanguage,
+            ['name', 'calculatedSlug']
+        ),
+        technology: extractFieldsFromNode(podcast.technology, [
+            'name',
+            'calculatedSlug',
+        ]),
+        seo: getSEO(podcast.seo),
+    }));
+
+    return insertTypename(podcasts, 'Podcast');
+};
+
 /**
  * Returns a list of all articles.
  * @param client -  The Apollo REST client that will be used to make the request.
  */
 const getAllPodcastsFromAPI = async (
-    client: UnderlyingClient<'ApolloREST'>
+    client: UnderlyingClient<'ApolloREST'> | UnderlyingClient<'ApolloGraphQL'>
 ): Promise<Podcast[]> => {
-    const query = gql`
+    const strapi_query = gql`
         query Podcasts {
             podcasts @rest(type: "Podcast", path: "/podcasts?_limit=-1") {
                 ${podcastFields}
@@ -77,29 +345,38 @@ const getAllPodcastsFromAPI = async (
         }
     `;
 
+    const isStrapi = isStrapiClient(client);
+    const query = isStrapi ? strapi_query : cs_query_all;
+
     const { data }: ApolloQueryResult<{ podcasts: Podcast[] }> =
         await client.query({ query });
 
-    return data.podcasts;
+    return formatResponse(isStrapi, data, true);
 };
 
 export const getPodcastBySlugFromAPI = async (
-    client: UnderlyingClient<'ApolloREST'>,
+    client: UnderlyingClient<'ApolloREST'> | UnderlyingClient<'ApolloGraphQL'>,
     slug: string
 ): Promise<Podcast | null> => {
-    const query = gql`
+    const strapi_query = gql`
         query Podcasts {
             podcasts @rest(type: "Podcast", path: "/podcasts?slug_eq=${slug}") {
                 ${podcastFields}
             }
         }
     `;
+
+    const isStrapi = isStrapiClient(client);
+    const query = isStrapi ? strapi_query : cs_query_by_slug;
+    const variables = isStrapi ? null : { slug };
+
     const { data }: ApolloQueryResult<{ podcasts: Podcast[] }> =
         await client.query({
             query,
+            variables,
         });
 
-    return data.podcasts.length > 0 ? data.podcasts[0] : null;
+    return formatResponse(isStrapi, data, false);
 };
 
 export default getAllPodcastsFromAPI;

--- a/src/api-requests/utils.ts
+++ b/src/api-requests/utils.ts
@@ -1,0 +1,74 @@
+import { TagType } from '../types/tag-type';
+import { CollectionType } from '../types/collection-type';
+
+/**
+ * Helper to access the desired fields through edges and node
+ * @param fields [sourceField, projectedField][] if they are different
+ * or field[] if both sourceField and projectField are the same
+ */
+export const extractFieldsFromNode = (
+    singleDataOfField: { [key: string]: any },
+    fields: [string, string][] | string[]
+): null | { [key: string]: any } => {
+    const projectedData: { [key: string]: any } = {};
+
+    if (singleDataOfField.edges.length === 0) {
+        return null;
+    }
+
+    const data = singleDataOfField.edges[0].node;
+    const sourceAndProjectFieldsAreDifferent = Array.isArray(fields[0]);
+
+    if (sourceAndProjectFieldsAreDifferent) {
+        for (const [sourceField, projectedField] of fields) {
+            projectedData[projectedField] = data[sourceField];
+        }
+
+        return projectedData;
+    }
+
+    // source field and project field are the same
+    for (const field of fields) {
+        projectedData[field as string] = data[field as string];
+    }
+
+    return projectedData;
+};
+
+/**
+ * This function will treat fields with [] and {} as non-empty, but SEO
+ * after formatting only has "" and null values and thus work
+ */
+const isEmptySEO = (seo: { [key: string]: any }) => {
+    for (const value of Object.values(seo)) {
+        if (value) {
+            return false;
+        }
+    }
+
+    return true;
+};
+
+export const getSEO = (seoData: {
+    [key: string]: any;
+}): null | { [key: string]: any } => {
+    let seo: { [key: string]: any } = {};
+
+    seo = {
+        ...seoData,
+        og_image: extractFieldsFromNode(seoData.og_image, ['url']),
+        twitter_image: extractFieldsFromNode(seoData.twitter_image, ['url']),
+    };
+
+    return !isEmptySEO(seo) ? seo : null;
+};
+
+export const insertTypename = (
+    data: { [key: string]: any }[],
+    __typename: TagType | CollectionType
+) => {
+    return data.map((d: { [key: string]: any }) => ({
+        ...d,
+        __typename,
+    }));
+};

--- a/src/api-requests/utils.ts
+++ b/src/api-requests/utils.ts
@@ -151,3 +151,31 @@ export const fetchAll = async (
 
     return allData;
 };
+
+export const areTheSame = (
+    list1: { [key: string]: any }[],
+    list2: { [key: string]: any }[],
+    comparatorFunc: (
+        a: { [key: string]: any },
+        b: { [key: string]: any }
+    ) => number,
+    isEqualFunc: (
+        a: { [key: string]: any },
+        b: { [key: string]: any }
+    ) => boolean
+): boolean => {
+    if (list1.length !== list2.length) {
+        return false;
+    }
+
+    list1.sort(comparatorFunc);
+    list2.sort(comparatorFunc);
+
+    for (let idx = 0; idx < list1.length; idx++) {
+        if (!isEqualFunc(list1[idx], list2[idx])) {
+            return false;
+        }
+    }
+
+    return true;
+};

--- a/src/config/api-client.ts
+++ b/src/config/api-client.ts
@@ -4,3 +4,20 @@ export const STRAPI_CLIENT = clientFactory(
     'ApolloREST',
     process.env.STRAPI_URL
 );
+
+const {
+    CS_URL: URL,
+    CS_STACK_API_KEY,
+    CS_ENVIRONMENT,
+    CS_ACCESS_TOKEN,
+    CS_BRANCH,
+} = process.env;
+
+const CS_URL = `${URL}/stacks/${CS_STACK_API_KEY}?environment=${CS_ENVIRONMENT}`;
+const CS_HEADERS = {
+    access_token: CS_ACCESS_TOKEN as string,
+    branch: CS_BRANCH as string,
+    'content-type': 'application/json',
+};
+
+export const CS_CLIENT = clientFactory('ApolloGraphQL', CS_URL, CS_HEADERS);

--- a/src/service/get-all-meta-info.ts
+++ b/src/service/get-all-meta-info.ts
@@ -1,4 +1,4 @@
-import { STRAPI_CLIENT } from '../config/api-client';
+import { CS_CLIENT } from '../config/api-client';
 import { MetaInfo, MetaInfoResponse } from '../interfaces/meta-info';
 import {
     getAllContentTypesMetaInfo,
@@ -12,6 +12,101 @@ import { CTA } from '../components/hero/types';
 import { getDistinctTags } from './get-distinct-tags';
 import { TagType } from '../types/tag-type';
 
+/**
+ * Recursive function to perform nested structural comparison on two lists
+ */
+// const compareLists = (list1: any[], list2: any[]): boolean => {
+//     if (list1.length !== list2.length) {
+//         return false;
+//     }
+
+//     for (let i = 0; i < list1.length; i++) {
+//         const item1 = list1[i];
+//         const item2 = list2[i];
+
+//         if (typeof item1 !== typeof item2) {
+//             return false;
+//         }
+
+//         if (
+//             Array.isArray(item1) &&
+//             Array.isArray(item2) &&
+//             !compareLists(item1, item2)
+//         ) {
+//             return false;
+//         }
+
+//         if (
+//             typeof item1 === 'object' &&
+//             typeof item2 === 'object' &&
+//             !compareLists(Object.values(item1), Object.values(item2))
+//         ) {
+//             return false;
+//         }
+
+//         // non-nested type at this point
+//         if (item1 !== item2) {
+//             return false;
+//         }
+//     }
+
+//     return true;
+// };
+
+// const parity_test_matched = async () => {
+//     const l1_products = compareLists(
+//         await getAllL1ProductsMetaInfo(CS_CLIENT),
+//         await getAllL1ProductsMetaInfo(STRAPI_CLIENT)
+//     );
+
+//     if (!l1_products) console.log('[DEBUG] l1_products do not match');
+
+//     const l2_products = compareLists(
+//         await getAllL2ProductsMetaInfo(CS_CLIENT),
+//         await getAllL2ProductsMetaInfo(STRAPI_CLIENT)
+//     );
+
+//     if (!l2_products) console.log('[DEBUG] l2_products do not match');
+
+//     const programmingLanguages = compareLists(
+//         await getAllProgrammingLanguagesMetaInfo(CS_CLIENT),
+//         await getAllProgrammingLanguagesMetaInfo(STRAPI_CLIENT)
+//     );
+
+//     if (!programmingLanguages)
+//         console.log('[DEBUG] programmingLanguages do not match');
+
+//     const technologies = compareLists(
+//         await getAllTechnologiesMetaInfo(CS_CLIENT),
+//         await getAllTechnologiesMetaInfo(STRAPI_CLIENT)
+//     );
+
+//     if (!technologies) console.log('[DEBUG] technologies do not match');
+
+//     const expertiseLevels = compareLists(
+//         await getAllExpertiseLevelsMetaInfo(CS_CLIENT),
+//         await getAllExpertiseLevelsMetaInfo(STRAPI_CLIENT)
+//     );
+
+//     if (!expertiseLevels) console.log('[DEBUG] expertiseLevels do not match');
+
+//     const contentTypes = compareLists(
+//         await getAllContentTypesMetaInfo(CS_CLIENT),
+//         await getAllContentTypesMetaInfo(STRAPI_CLIENT)
+//     );
+
+//     if (!contentTypes) console.log('[DEBUG] contentTypes do not match');
+
+//     return (
+//         l1_products &&
+//         l2_products &&
+//         programmingLanguages &&
+//         technologies &&
+//         expertiseLevels &&
+//         contentTypes
+//     );
+// };
+
 export const getAllMetaInfo = async (): Promise<MetaInfo[]> => {
     const existingTags = await getDistinctTags();
     // We have no use for tags that have no content associated with them
@@ -21,13 +116,18 @@ export const getAllMetaInfo = async (): Promise<MetaInfo[]> => {
                 ({ slug, type }) => slug === tag.slug && type === category
             )
         );
+
+    // if (!(await parity_test_matched())) {
+    //     throw new Error('Parity Test for meta-info Failed.');
+    // }
+
     const l2MetaInfoResponse = getExisting(
-        await getAllL2ProductsMetaInfo(STRAPI_CLIENT),
+        await getAllL2ProductsMetaInfo(CS_CLIENT),
         'L2Product'
     );
 
     const l1ProductsMetaInfo = parseMetaInfoResponseForL1(
-        getExisting(await getAllL1ProductsMetaInfo(STRAPI_CLIENT), 'L1Product'),
+        getExisting(await getAllL1ProductsMetaInfo(CS_CLIENT), 'L1Product'),
         l2MetaInfoResponse
     );
 
@@ -35,27 +135,23 @@ export const getAllMetaInfo = async (): Promise<MetaInfo[]> => {
 
     const programmingLanguagesMetaInfo = parseMetaInfoResponse(
         getExisting(
-            await getAllProgrammingLanguagesMetaInfo(STRAPI_CLIENT),
+            await getAllProgrammingLanguagesMetaInfo(CS_CLIENT),
             'ProgrammingLanguage'
         )
     );
+
     const technologiesMetaInfo = parseMetaInfoResponse(
-        getExisting(
-            await getAllTechnologiesMetaInfo(STRAPI_CLIENT),
-            'Technology'
-        )
+        getExisting(await getAllTechnologiesMetaInfo(CS_CLIENT), 'Technology')
     );
+
     const expertiseLevelsMetaInfo = parseMetaInfoResponse(
         getExisting(
-            await getAllExpertiseLevelsMetaInfo(STRAPI_CLIENT),
+            await getAllExpertiseLevelsMetaInfo(CS_CLIENT),
             'ExpertiseLevel'
         )
     );
     const contentTypesMetaInfo = parseMetaInfoResponse(
-        getExisting(
-            await getAllContentTypesMetaInfo(STRAPI_CLIENT),
-            'ContentType'
-        )
+        getExisting(await getAllContentTypesMetaInfo(CS_CLIENT), 'ContentType')
     );
     return l1ProductsMetaInfo
         .concat(l2ProductsMetaInfo)

--- a/src/service/get-all-meta-info.ts
+++ b/src/service/get-all-meta-info.ts
@@ -12,101 +12,6 @@ import { CTA } from '../components/hero/types';
 import { getDistinctTags } from './get-distinct-tags';
 import { TagType } from '../types/tag-type';
 
-/**
- * Recursive function to perform nested structural comparison on two lists
- */
-// const compareLists = (list1: any[], list2: any[]): boolean => {
-//     if (list1.length !== list2.length) {
-//         return false;
-//     }
-
-//     for (let i = 0; i < list1.length; i++) {
-//         const item1 = list1[i];
-//         const item2 = list2[i];
-
-//         if (typeof item1 !== typeof item2) {
-//             return false;
-//         }
-
-//         if (
-//             Array.isArray(item1) &&
-//             Array.isArray(item2) &&
-//             !compareLists(item1, item2)
-//         ) {
-//             return false;
-//         }
-
-//         if (
-//             typeof item1 === 'object' &&
-//             typeof item2 === 'object' &&
-//             !compareLists(Object.values(item1), Object.values(item2))
-//         ) {
-//             return false;
-//         }
-
-//         // non-nested type at this point
-//         if (item1 !== item2) {
-//             return false;
-//         }
-//     }
-
-//     return true;
-// };
-
-// const parity_test_matched = async () => {
-//     const l1_products = compareLists(
-//         await getAllL1ProductsMetaInfo(CS_CLIENT),
-//         await getAllL1ProductsMetaInfo(STRAPI_CLIENT)
-//     );
-
-//     if (!l1_products) console.log('[DEBUG] l1_products do not match');
-
-//     const l2_products = compareLists(
-//         await getAllL2ProductsMetaInfo(CS_CLIENT),
-//         await getAllL2ProductsMetaInfo(STRAPI_CLIENT)
-//     );
-
-//     if (!l2_products) console.log('[DEBUG] l2_products do not match');
-
-//     const programmingLanguages = compareLists(
-//         await getAllProgrammingLanguagesMetaInfo(CS_CLIENT),
-//         await getAllProgrammingLanguagesMetaInfo(STRAPI_CLIENT)
-//     );
-
-//     if (!programmingLanguages)
-//         console.log('[DEBUG] programmingLanguages do not match');
-
-//     const technologies = compareLists(
-//         await getAllTechnologiesMetaInfo(CS_CLIENT),
-//         await getAllTechnologiesMetaInfo(STRAPI_CLIENT)
-//     );
-
-//     if (!technologies) console.log('[DEBUG] technologies do not match');
-
-//     const expertiseLevels = compareLists(
-//         await getAllExpertiseLevelsMetaInfo(CS_CLIENT),
-//         await getAllExpertiseLevelsMetaInfo(STRAPI_CLIENT)
-//     );
-
-//     if (!expertiseLevels) console.log('[DEBUG] expertiseLevels do not match');
-
-//     const contentTypes = compareLists(
-//         await getAllContentTypesMetaInfo(CS_CLIENT),
-//         await getAllContentTypesMetaInfo(STRAPI_CLIENT)
-//     );
-
-//     if (!contentTypes) console.log('[DEBUG] contentTypes do not match');
-
-//     return (
-//         l1_products &&
-//         l2_products &&
-//         programmingLanguages &&
-//         technologies &&
-//         expertiseLevels &&
-//         contentTypes
-//     );
-// };
-
 export const getAllMetaInfo = async (): Promise<MetaInfo[]> => {
     const existingTags = await getDistinctTags();
     // We have no use for tags that have no content associated with them
@@ -116,10 +21,6 @@ export const getAllMetaInfo = async (): Promise<MetaInfo[]> => {
                 ({ slug, type }) => slug === tag.slug && type === category
             )
         );
-
-    // if (!(await parity_test_matched())) {
-    //     throw new Error('Parity Test for meta-info Failed.');
-    // }
 
     const l2MetaInfoResponse = getExisting(
         await getAllL2ProductsMetaInfo(CS_CLIENT),

--- a/src/service/get-all-meta-info.ts
+++ b/src/service/get-all-meta-info.ts
@@ -26,7 +26,6 @@ export const getAllMetaInfo = async (): Promise<MetaInfo[]> => {
         await getAllL2ProductsMetaInfo(CS_CLIENT),
         'L2Product'
     );
-
     const l1ProductsMetaInfo = parseMetaInfoResponseForL1(
         getExisting(await getAllL1ProductsMetaInfo(CS_CLIENT), 'L1Product'),
         l2MetaInfoResponse

--- a/src/service/get-all-podcasts.ts
+++ b/src/service/get-all-podcasts.ts
@@ -1,4 +1,4 @@
-import { STRAPI_CLIENT } from '../config/api-client';
+import { CS_CLIENT } from '../config/api-client';
 import { Podcast } from '../interfaces/podcast';
 import getAllPodcastsFromAPI, {
     getPodcastBySlugFromAPI,
@@ -36,14 +36,15 @@ const setPodcastTags = (podcasts: Podcast[]) => {
 };
 
 export const getAllPodcasts = async (): Promise<Podcast[]> => {
-    const podcasts = await getAllPodcastsFromAPI(STRAPI_CLIENT);
+    const podcasts = await getAllPodcastsFromAPI(CS_CLIENT);
+    console.log(podcasts);
     return setPodcastTags(podcasts);
 };
 
 export const getPodcastBySlug = async (
     slug: string
 ): Promise<Podcast | null> => {
-    const podcast = await getPodcastBySlugFromAPI(STRAPI_CLIENT, slug);
+    const podcast = await getPodcastBySlugFromAPI(CS_CLIENT, slug);
     if (!podcast) return null;
     const modifiedPodcasts = setPodcastTags([podcast]);
     return modifiedPodcasts.length > 0 ? modifiedPodcasts[0] : null;

--- a/src/service/get-all-podcasts.ts
+++ b/src/service/get-all-podcasts.ts
@@ -17,6 +17,7 @@ const setPodcastTags = (podcasts: Podcast[]) => {
             contentType: contentType,
         },
     }));
+
     modifiedPodcasts.forEach(p => {
         if (p.l1Product) {
             p.otherTags.l1Product = p.l1Product;
@@ -37,7 +38,7 @@ const setPodcastTags = (podcasts: Podcast[]) => {
 
 export const getAllPodcasts = async (): Promise<Podcast[]> => {
     const podcasts = await getAllPodcastsFromAPI(CS_CLIENT);
-    console.log(podcasts);
+
     return setPodcastTags(podcasts);
 };
 

--- a/src/utils/client-factory.ts
+++ b/src/utils/client-factory.ts
@@ -15,7 +15,8 @@ import { RetryLink } from '@apollo/client/link/retry';
  */
 const clientFactory = <T extends ClientType>(
     clientType: T,
-    uri: string | undefined
+    uri: string | undefined,
+    headers?: Record<string, string>
 ): UnderlyingClient<T> => {
     const defaultOptions: DefaultOptions = {
         watchQuery: {
@@ -54,10 +55,22 @@ const clientFactory = <T extends ClientType>(
             return new ApolloClient({
                 cache: new InMemoryCache(),
                 uri,
+                headers,
             }) as UnderlyingClient<T>;
         default:
             throw Error('Invalid client type.');
     }
 };
 
-export { clientFactory };
+/**
+ * Determine whether a client is a Strapi_Client (RESTful) or CS_Client (GraphQL)
+ * by using the fact that Strapi Client's .link is ApolloLink and
+ * CS Client's .link is HttpLink
+ */
+const isStrapiClient = (
+    client: UnderlyingClient<'ApolloREST'> | UnderlyingClient<'ApolloGraphQL'>
+): boolean => {
+    return client.link.constructor === ApolloLink;
+};
+
+export { clientFactory, isStrapiClient };


### PR DESCRIPTION
## Jira Ticket:

[DEVHUB-1744](https://jira.mongodb.org/browse/DEVHUB-1744)

## Updates:
1. Frontend now takes podcasts and taxonomy metadata from ContentStack
2. Add initial parity testing code; upon executing it, **it uncovers that `primary_cta` was not migrated to l1_products on ContentStack, and possibly to other taxonomy data (see screenshot below)**
3. From consumption perspective, it went from `getAllContentTypesMetaInfo(STRAPI_CLIENT)` to `getAllContentTypesMetaInfo(CS_CLIENT)`, similarly for others

## Remarks:
1. My intent was to minimize the downward impact on the front end, so the ContentStack response was 100% reformatted into Strapi response format upon receipt
3. All codes were executed on `production` environment and `apr_28` branch
4. I was playing fast and loose to use many `any` types to set up the framework for your review; I can definitely go back and add more type checking to better comply with the codebase standard
5. I also kept ApolloClient, as part of the attempt to minimize code changes

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/39178325/236501973-36d5fab6-6d1b-4cb2-87cf-4724303380d4.png)

