### PR TITLE
Devhub-1691 Adding redirect

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -2303,5 +2303,10 @@
         "source": "/products/mongodb/generate-mql-with-mognosh-and-openai/",
         "destination": "/products/mongodb/generate-mql-with-mongosh-and-openai/",
         "permanent": true
+    },
+    {
+        "source": "/products/mongodb/getting-started-mongodb-c/",
+        "destination": "/products/mongodb/getting-started-mongodb-cpp/",
+        "permanent": true
     }
 ]


### PR DESCRIPTION
https://jira.mongodb.org/browse/DEVHUB-1691

Opening this PR directly to production since main has Mongodb TV code - which we do not want to push to production yet.