### PR TITLE
[DEVHUB-1797] Fix added Video and Podcast content type tag format

### DIFF
--- a/src/service/get-all-podcasts.ts
+++ b/src/service/get-all-podcasts.ts
@@ -3,18 +3,18 @@ import {
     getAllPodcastsFromAPI,
     getPodcastBySlugFromAPI,
 } from '../api-requests/get-podcasts';
-import { ContentTypeTag } from '../interfaces/tag-type-response';
+import { ContentTypeConnection } from '../interfaces/other-tags';
 
 const setPodcastTags = (podcasts: CS_PodcastResponse[]) => {
-    const contentType: ContentTypeTag = {
-        contentType: 'Podcast',
-        calculatedSlug: '/podcasts',
+    // Simulate a content type connection
+    const content_typeConnection: ContentTypeConnection = {
+        edges: [{ node: { title: 'Podcast', calculated_slug: '/podcasts' } }],
     };
     const modifiedPodcasts = podcasts.map((item: CS_PodcastResponse) => ({
         ...item,
         other_tags: {
             ...item.other_tags,
-            contentType: contentType,
+            content_typeConnection,
         },
     }));
     modifiedPodcasts.forEach((p: CS_PodcastResponse) => {

--- a/src/service/get-all-videos.ts
+++ b/src/service/get-all-videos.ts
@@ -2,19 +2,19 @@ import { CS_VideoResponse } from '../interfaces/video';
 import getAllVideosFromAPI, {
     getVideoBySlugFromAPI,
 } from '../api-requests/get-videos';
-import { ContentTypeTag } from '../interfaces/tag-type-response';
+import { ContentTypeConnection } from '../interfaces/other-tags';
 
 const setVideoTags = (videos: CS_VideoResponse[]) => {
-    const contentType: ContentTypeTag = {
-        contentType: 'Video',
-        calculatedSlug: '/videos',
+    // Simulate a content type connection
+    const content_typeConnection: ContentTypeConnection = {
+        edges: [{ node: { title: 'Video', calculated_slug: '/videos' } }],
     };
     const modifiedVideos: CS_VideoResponse[] = videos.map(
         (item: CS_VideoResponse) => ({
             ...item,
             other_tags: {
                 ...item.other_tags,
-                contentType: contentType,
+                content_typeConnection,
             },
         })
     );


### PR DESCRIPTION
## Jira Ticket:

[DEVHUB-1797](https://jira.mongodb.org/browse/DEVHUB-1797)

## Description:

We manually add content type tags for Videos and Podcast, and we were still adding them in the old format. This was causing them not to be picked up by various other logic.