### PR TITLE
Add stopPropagation to prevent menu from clsoing itself.

### DIFF
--- a/src/components/secondary-nav/desktop.tsx
+++ b/src/components/secondary-nav/desktop.tsx
@@ -162,6 +162,7 @@ const DesktopView = ({ activePath }: { activePath: string | undefined }) => {
                                                     : false
                                             )}
                                             onClick={onClickShowMenu}
+                                            stopPropagation
                                         >
                                             {name}
                                             <SystemIcon


### PR DESCRIPTION
## Description:

Due to Flora changes, the Link component no longer stops event propagation by default. This meant that our event listener that checks for clicks outside the dropdown to close it was registering and was closing the menu immediately after opening.
