### PR TITLE
[DEVHUB]-1807 Stale Responses from ContentStack Graphql API's impacting previews

### DIFF
--- a/playwright-tests/pages/[...slug].spec.ts
+++ b/playwright-tests/pages/[...slug].spec.ts
@@ -20,18 +20,18 @@ test('Content page has all components on tutorial', async ({ page }) => {
     // Breadcrumbs
     expect(
         await page
-            .locator('div[data-testid="breadcrumbs"] a:has-text("*Tutorials")')
+            .locator('div[data-testid="breadcrumbs"] a:has-text("Tutorials")')
             .count()
     ).toEqual(1);
 
     // Title
     const title = page.locator('h1');
     expect(title).toHaveText(
-        '*Building an E-commerce Content Catalog with Atlas Search'
+        'Building an E-commerce Content Catalog with Atlas Search'
     );
 
     // Author Lockup
-    const authorName = page.locator('"*Joel Lord"');
+    const authorName = page.locator('"Joel Lord"');
     expect(await authorName.getAttribute('href')).toBe(
         '/developer/author/joel-lord/'
     );
@@ -54,7 +54,7 @@ test('Content page has all components on tutorial', async ({ page }) => {
 
     // Rating, top and bottom
     expect(
-        await page.locator('span:has-text("Rate this *tutorial")').count()
+        await page.locator('span:has-text("Rate this tutorial")').count()
     ).toEqual(2);
     expect(await page.locator('div[aria-label="One Star"]').count()).toEqual(2);
 
@@ -71,7 +71,7 @@ test('Content page has all components on tutorial', async ({ page }) => {
 
     // Request button
     expect(
-        await page.locator('button:text("Request a *Tutorial")').count()
+        await page.locator('button:text("Request a Tutorial")').count()
     ).toEqual(1);
 });
 
@@ -82,8 +82,8 @@ test('request content flow on content page works', async ({ page }) => {
         route.fulfill();
     });
     await Promise.all([
-        page.waitForSelector('h5:text("Request a *Tutorial")'),
-        page.locator('button:text("Request a *Tutorial")').click(),
+        page.waitForSelector('h5:text("Request a Tutorial")'),
+        page.locator('button:text("Request a Tutorial")').click(),
     ]);
 
     await page.locator('#topic').click();
@@ -145,7 +145,7 @@ test('1 star rating flow on content page', async ({ page }) => {
         (await page.locator('div[aria-label="Five Stars"]').nth(0)).click(),
     ]);
     await Promise.all([
-        page.waitForSelector('"How can we improve this *tutorial?"'),
+        page.waitForSelector('"How can we improve this tutorial?"'),
         page.locator('button:has-text("Tell us more")').click(),
     ]);
     await Promise.all([
@@ -183,7 +183,7 @@ test('3 star rating flow on content page', async ({ page }) => {
         (await page.locator('div[aria-label="Five Stars"]').nth(0)).click(),
     ]);
     await Promise.all([
-        page.waitForSelector('"How can we improve this *tutorial?"'),
+        page.waitForSelector('"How can we improve this tutorial?"'),
         page.locator('button:has-text("Tell us more")').click(),
     ]);
     await Promise.all([
@@ -210,7 +210,7 @@ test('5 star rating flow on content page', async ({ page }) => {
         (await page.locator('div[aria-label="Five Stars"]').nth(0)).click(),
     ]);
     await Promise.all([
-        page.waitForSelector('"How can we improve this *tutorial?"'),
+        page.waitForSelector('"How can we improve this tutorial?"'),
         page.locator('button:has-text("Tell us more")').click(),
     ]);
     await Promise.all([

--- a/src/api-requests/contentstack_utils.ts
+++ b/src/api-requests/contentstack_utils.ts
@@ -7,6 +7,7 @@ import {
 } from '../config/api-client';
 import { ContentTypeUID } from '../interfaces/meta-info';
 import { UnderlyingClient } from '../types/client-factory';
+import { FetchPolicy } from '@apollo/client/core';
 
 type environment = 'production' | 'staging';
 
@@ -26,12 +27,14 @@ export const fetchAll = async (
     query: DocumentNode,
     contentTypeUID: ContentTypeUID,
     client: UnderlyingClient<'ApolloGraphQL'>,
-    variables?: Record<string, any>
+    variables?: Record<string, any>,
+    fetchPolicy: FetchPolicy = 'cache-first'
 ) => {
     // expect all incoming cs_query already has total
     const response: ApolloQueryResult<any> = await client.query({
         query,
         variables,
+        fetchPolicy,
     });
 
     const { total } = response.data[contentTypeUID];
@@ -43,6 +46,7 @@ export const fetchAll = async (
         const res: ApolloQueryResult<any> = await client.query({
             query,
             variables: variablesWithSkip,
+            fetchPolicy,
         });
         const { items } = res.data[contentTypeUID];
 

--- a/src/api-requests/get-articles.ts
+++ b/src/api-requests/get-articles.ts
@@ -39,7 +39,8 @@ export const CS_getDraftArticleBySlugFromCMS = async (
         getArticleQuery,
         'articles',
         client,
-        variables
+        variables,
+        'no-cache'
     )) as CS_ArticleResponse[];
 
     return articles[0];

--- a/src/api-requests/get-articles.ts
+++ b/src/api-requests/get-articles.ts
@@ -32,7 +32,7 @@ export const CS_getArticleBySlugFromCMS = async (
 
 export const CS_getDraftArticleBySlugFromCMS = async (
     calculatedSlug: string
-): Promise<CS_ArticleResponse> => {
+): Promise<CS_ArticleResponse | undefined> => {
     const client = getClient('staging');
     const variables = { calculatedSlug };
     const articles = (await fetchAll(

--- a/src/api-requests/get-industry-events.ts
+++ b/src/api-requests/get-industry-events.ts
@@ -49,7 +49,8 @@ export const CS_getDraftIndustryEventBySlugFromCMS = async (
         getIndustryEventQuery,
         'industry_events',
         client,
-        variables
+        variables,
+        'no-cache'
     )) as CS_IndustryEventsResponse[];
 
     return industryEvents[0];

--- a/src/pages/preview/[...slug].tsx
+++ b/src/pages/preview/[...slug].tsx
@@ -9,11 +9,12 @@ import {
     getPreviewContentForArticles,
     getPreviewContentForEvents,
 } from '../../service/get-preview-content';
+import Error from 'next/error';
 
 interface ContentPageProps {
     crumbs: Crumb[];
     topic: Tag;
-    contentItem: ContentItem;
+    contentItem: ContentItem | null;
     relatedContent: ContentItem[];
     tertiaryNavItems: TertiaryNavItem[];
     previewMode?: boolean;
@@ -27,6 +28,10 @@ const ContentPage: NextPage<ContentPageProps> = ({
     relatedContent,
     previewMode,
 }) => {
+    if (!contentItem) {
+        return <Error statusCode={404} />;
+    }
+
     return (
         <ContentPageTemplate
             crumbs={crumbs}
@@ -49,7 +54,7 @@ export const getServerSideProps = async (context: any) => {
         type: 'Technology',
         slug: '',
     };
-    let contentItem;
+    let contentItem: ContentItem | null;
     if (slugString.startsWith('events/')) {
         contentItem = await getPreviewContentForEvents('/' + slugString);
     } else {

--- a/src/pages/preview/[...slug].tsx
+++ b/src/pages/preview/[...slug].tsx
@@ -28,9 +28,8 @@ const ContentPage: NextPage<ContentPageProps> = ({
     relatedContent,
     previewMode,
 }) => {
-    if (!contentItem) {
-        return <Error statusCode={404} />;
-    }
+    const isStaging = process.env.APP_ENV === 'staging';
+    if (!contentItem || isStaging) return <Error statusCode={404} />;
 
     return (
         <ContentPageTemplate

--- a/src/pages/preview/[...slug].tsx
+++ b/src/pages/preview/[...slug].tsx
@@ -1,20 +1,18 @@
 import type { NextPage } from 'next';
-import React from 'react';
 import { Crumb } from '../../components/breadcrumbs/types';
-import { ContentItem } from '../../interfaces/content-item';
 import { TertiaryNavItem } from '../../components/tertiary-nav/types';
-import ContentPageTemplate from '../../page-templates/content-page/content-page-template';
+import { ContentItem } from '../../interfaces/content-item';
 import { Tag } from '../../interfaces/tag';
+import ContentPageTemplate from '../../page-templates/content-page/content-page-template';
 import {
     getPreviewContentForArticles,
     getPreviewContentForEvents,
 } from '../../service/get-preview-content';
-import Error from 'next/error';
 
 interface ContentPageProps {
     crumbs: Crumb[];
     topic: Tag;
-    contentItem: ContentItem | null;
+    contentItem: ContentItem;
     relatedContent: ContentItem[];
     tertiaryNavItems: TertiaryNavItem[];
     previewMode?: boolean;
@@ -28,9 +26,6 @@ const ContentPage: NextPage<ContentPageProps> = ({
     relatedContent,
     previewMode,
 }) => {
-    const isStaging = process.env.APP_ENV === 'staging';
-    if (!contentItem || isStaging) return <Error statusCode={404} />;
-
     return (
         <ContentPageTemplate
             crumbs={crumbs}
@@ -59,6 +54,9 @@ export const getServerSideProps = async (context: any) => {
     } else {
         contentItem = await getPreviewContentForArticles('/' + slugString);
     }
+
+    const isStaging = process.env.APP_ENV === 'staging';
+    if (!contentItem || isStaging) return { notFound: true };
 
     const result = {
         crumbs: [],

--- a/src/service/get-preview-content.ts
+++ b/src/service/get-preview-content.ts
@@ -8,8 +8,9 @@ import { CS_getDraftIndustryEventBySlugFromCMS } from '../api-requests/get-indus
 
 export const getPreviewContentForArticles: (
     calculatedSlug: string
-) => Promise<ContentItem> = async calculatedSlug => {
+) => Promise<ContentItem | null> = async calculatedSlug => {
     const content = await CS_getDraftArticleBySlugFromCMS(calculatedSlug);
+    if (!content) return null;
     const mappedArticles = CS_mapArticlesToContentItems([content], []);
     return mappedArticles[0];
 };

--- a/src/utils/client-factory.ts
+++ b/src/utils/client-factory.ts
@@ -63,7 +63,6 @@ const clientFactory = <T extends ClientType>(
                     new HttpLink({
                         uri,
                         headers,
-                        fetchOptions: { method: 'GET' }, // override default POST to use GET
                     }),
             }) as UnderlyingClient<T>;
         case 'Mock':
@@ -75,7 +74,6 @@ const clientFactory = <T extends ClientType>(
                     new HttpLink({
                         uri,
                         headers,
-                        fetchOptions: { method: 'GET' },
                     }),
                 ]),
             }) as UnderlyingClient<T>;


### PR DESCRIPTION
## Jira Ticket:

[DEVHUB-1807](https://jira.mongodb.org/browse/DEVHUB-1807)

## Updates:

1. Updated `fetchAll()` to have a `fetchPolicy`; for staging-related requests, `no-cache` is used to avoid stale responses
2. Changed ApolloClient from GET (with URI encoding) to POST (default option) to avoid occasional URI-too-long error code from Contentstack
3. Updated UI to render 404 page (instead of a 5xx error) when a content is not found, which happens when a preview content is not found