### PR TITLE
Dynamically import to avoid async issue

### DIFF
--- a/mocks/update-apollo-mocks.ts
+++ b/mocks/update-apollo-mocks.ts
@@ -1,18 +1,12 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
 
 import { DocumentNode } from 'graphql';
-import { fetchAllForMocks } from '../src/api-requests/contentstack_utils';
-import { getAllIndustryEventsQuery } from '../src/graphql/industry-events';
-import { getAllPodcastsQuery } from '../src/graphql/podcasts';
-import { getAllVideosQuery } from '../src/graphql/videos';
+import { getAllArticleSeriesQuery } from '../src/graphql/article-series';
 import { getAllArticlesQuery } from '../src/graphql/articles';
 import { getAllAuthorsQuery } from '../src/graphql/authors';
-import { getAllArticleSeriesQuery } from '../src/graphql/article-series';
-import { getAllPodcastSeriesQuery } from '../src/graphql/podcast-series';
-import { getAllVideoSeriesQuery } from '../src/graphql/video-series';
 import { getAllFeaturedContentQuery } from '../src/graphql/featured-content';
-import { ContentTypeUID } from '../src/interfaces/meta-info';
+import { getAllIndustryEventsQuery } from '../src/graphql/industry-events';
 import {
     getAllAuthorTypesQuery,
     getAllContentTypesQuery,
@@ -23,6 +17,11 @@ import {
     getAllSpokenLanguagesQuery,
     getAllTechnologiesQuery,
 } from '../src/graphql/meta-info';
+import { getAllPodcastSeriesQuery } from '../src/graphql/podcast-series';
+import { getAllPodcastsQuery } from '../src/graphql/podcasts';
+import { getAllVideoSeriesQuery } from '../src/graphql/video-series';
+import { getAllVideosQuery } from '../src/graphql/videos';
+import { ContentTypeUID } from '../src/interfaces/meta-info';
 
 interface QueryInfo {
     query: DocumentNode;
@@ -143,6 +142,11 @@ export const queryInfos: QueryInfo[] = [
 // };
 
 const updateLocalMockData = async () => {
+    // dynamically import modules to ensure synchronousity
+    const { fetchAllForMocks } = await import(
+        '../src/api-requests/contentstack_utils'
+    );
+
     for (const { query, contentTypeUID, variables } of queryInfos) {
         const mockData = await fetchAllForMocks(
             query,


### PR DESCRIPTION
### Updates

- Dynamically import files to resolve the ReferenceError in jest test, which arises when the main branch is merged

### Issue 1: ReferenceError - fixed

- In the [last merged commit](https://github.com/mongodb/devcenter/commit/416da46ea18c74030d5b23c0072ef46e2a482f1b), the [jest-test failed](https://github.com/mongodb/devcenter/actions/runs/5413289150/jobs/9838629916)
- Let me know what you think @mcolella14, but my guess is that the top-level function being run in the file is an asynchronous function, which may precede the import statements
- ![image](https://github.com/mongodb/devcenter/assets/39178325/0bbf20f5-4982-4a8e-baf4-a6c1507f02e1)

### Issue 2: host name is not configured under images in your `next.config.js`

