### PR TITLE
Add more SEO fields

### DIFF
--- a/src/graphql/articles.ts
+++ b/src/graphql/articles.ts
@@ -153,6 +153,15 @@ const articleFields = gql`
             og_type
             og_url
             twitter_creator
+            twitter_card
+            twitter_description
+            twitter_imageConnection {
+                edges {
+                    node {
+                        url
+                    }
+                }
+            }
         }
         system {
             updated_at

--- a/src/page-templates/content-page/content-page-template.tsx
+++ b/src/page-templates/content-page/content-page-template.tsx
@@ -619,6 +619,13 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
             </>
         );
     };
+    const ogType =
+        seo?.og_type ||
+        ['Article', 'Code Example', 'Quickstart', 'Tutorial'].includes(category)
+            ? 'article'
+            : category === 'Video'
+            ? 'video:other'
+            : undefined;
 
     return (
         <>
@@ -632,11 +639,18 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                 openGraph={{
                     url: seo?.og_url,
                     title: seo?.og_title,
-                    type: seo?.og_type,
+                    type: ogType,
                     description: seo?.og_description,
                     images: seo?.og_image?.url
                         ? [{ url: seo?.og_image?.url }]
                         : [],
+                    article: {
+                        publishedTime: Array.isArray(contentDate)
+                            ? undefined
+                            : contentDate,
+                        modifiedTime: updateDate,
+                        authors: authors.map(({ name }) => name),
+                    },
                 }}
                 description={
                     seo?.meta_description ||

--- a/src/page-templates/content-page/content-page-template.tsx
+++ b/src/page-templates/content-page/content-page-template.tsx
@@ -649,7 +649,11 @@ const ContentPageTemplate: NextPage<ContentPageProps> = ({
                             ? undefined
                             : contentDate,
                         modifiedTime: updateDate,
-                        authors: authors.map(({ name }) => name),
+                        authors: authors.map(
+                            ({ calculated_slug }) =>
+                                publicRuntimeConfig.absoluteBasePath +
+                                calculated_slug
+                        ),
                     },
                 }}
                 description={

--- a/src/service/build-content-items.ts
+++ b/src/service/build-content-items.ts
@@ -378,7 +378,7 @@ export const CS_mapArticlesToContentItems = (
             codeType: a.other_tags.code_type,
             githubUrl: a.other_tags.github_url,
             liveSiteUrl: a.other_tags.livesite_url,
-            seo: a.seo,
+            seo: mapSEO(a.seo) as SEO,
         };
         const image = a.imageConnection.edges[0];
         if (image) {
@@ -435,7 +435,7 @@ export const CS_previewMapPreviewArticleToContentItem = (
         codeType: code_type,
         githubUrl: github_url,
         liveSiteUrl: livesite_url,
-        seo: a.seo,
+        seo: mapSEO(a.seo) as SEO,
         image: {
             url: a.image.url,
             alt: a.image.description || '',


### PR DESCRIPTION
## Description:

- Provide a default `og:type` of `article` or `video:other` when appropriate.
- Add missing GraphQL twitter-related fields.
- Add `publishedTime`, `modifiedTime`, and `authors` for articles.
