### PR TITLE
[DEVHUB-1875] Fix broken load more button

### DIFF
--- a/src/components/search/results.tsx
+++ b/src/components/search/results.tsx
@@ -52,9 +52,9 @@ const SearchResults: React.FunctionComponent<ResultsProps> = ({
         }
     }, [pageNumber, filters, searchString, sortBy]);
 
-    useEffect(() => {
-        setCurrentPage(startPage);
-    }, [results]);
+    // useEffect(() => {
+    //     setCurrentPage(startPage);
+    // }, [results]);
 
     const onLoadMore = (event: React.MouseEvent<HTMLAnchorElement>) => {
         event.preventDefault();


### PR DESCRIPTION
### Issue

1. Load More button does not render more content when clicked on DevCenter UI

### Current Implementation of Pagination

1. Pass a list of ALL the content to the `SearchResult` component
2. Use the [page to slice the content](https://github.com/mongodb/devcenter/blob/877626a512ca79e4f17be43fa8fae7081e538235/src/components/search/results.tsx#L39)
3. [Load More updates `page`](https://github.com/mongodb/devcenter/blob/877626a512ca79e4f17be43fa8fae7081e538235/src/components/search/results.tsx#L61), which is a state managed by React, prompting the React component to render   

### Cause of Broken Load More

1. There is a [`useEffect()` with dependency of `results`](https://github.com/mongodb/devcenter/blob/877626a512ca79e4f17be43fa8fae7081e538235/src/components/search/results.tsx#L55), which changes after [`onLoadMore`](https://github.com/mongodb/devcenter/blob/877626a512ca79e4f17be43fa8fae7081e538235/src/components/search/results.tsx#L59)
2. The useEffect() invokes setCurrentPage(startPage), resetting the page back to startPage and not rendering an expanded sliced range of content

### I think my solution is not the root fix

1. I think the root cause is to investigate why [`results`](https://github.com/mongodb/devcenter/blob/877626a512ca79e4f17be43fa8fae7081e538235/src/components/search/results.tsx#L57) changes
2. That said, I currently do not see the harm of removing the `useEffect()` and thus pushed this PR