### PR TITLE
[DEVHUB-1907] fix(sentry): Patch apollo error due to incorrect graphql syntax

### DIFF
--- a/src/graphql/authors.ts
+++ b/src/graphql/authors.ts
@@ -35,7 +35,7 @@ export const getAllAuthorsQuery = gql`
 `;
 
 export const getAuthorQuery = gql`
-    query get_author($calculatedSlug: string, $skip: Int = 0) {
+    query get_author($calculatedSlug: String!, $skip: Int = 0) {
         authors: all_authors(
             where: { calculated_slug: $calculatedSlug }
             skip: $skip


### PR DESCRIPTION
### Ticket

- [Fix the ApolloError in Sentry](https://jira.mongodb.org/browse/DEVHUB-1907)


### Updates

- Fix a typo which causes corrupted `gql` syntax and leads to `ApolloErrors`

