### PR TITLE
adding fix for youtube wrong rerender

### DIFF
--- a/src/utils/markdown-parser/convert-references.ts
+++ b/src/utils/markdown-parser/convert-references.ts
@@ -6,5 +6,5 @@ export const convertReferences = async (content: string) => {
     const markdownWithInLine = await remark()
         .use(remarkInlineLinks)
         .process(markdownWithReferences);
-    return markdownWithInLine.toString();
+    return markdownWithInLine.toString().replace('youtube\\[]', 'youtube[]');
 };


### PR DESCRIPTION
const markdownWithInLine = await remark()
        .use(remarkInlineLinks)
        .process(markdownWithReferences);
 is breaking youtube embeddings , the above is a patch to undo the change introduced to youtube embeddings while converting references to inline links.
