### PR TITLE
DEVHUB-1938 pulling original publish date from publish metadata colle…

### DIFF
--- a/src/api-requests/get-articles.ts
+++ b/src/api-requests/get-articles.ts
@@ -1,6 +1,10 @@
 import { getAllArticlesQuery, getArticleQuery } from '../graphql/articles';
 import { CS_ArticleResponse } from '../interfaces/article';
 import { fetchAll, getClient } from './contentstack_utils';
+import { getPublishingMetadataQuery } from '../graphql/publish-metdata';
+import { CS_PublishMetadataResponse } from '../interfaces/publish-metadata';
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import { getPublishMetadataAsMap } from './get-publish-metadata';
 
 export const CS_getAllArticlesFromCMS = async (): Promise<
     CS_ArticleResponse[]
@@ -11,8 +15,48 @@ export const CS_getAllArticlesFromCMS = async (): Promise<
         'articles',
         client
     )) as CS_ArticleResponse[];
-
+    const publishMetadataMap = await getPublishMetadataAsMap();
+    CS_adjustOriginalPublishDateForAllArticles(articles, publishMetadataMap);
     return articles;
+};
+
+const CS_adjustOriginalPublishDateForAllArticles = (
+    articles: CS_ArticleResponse[],
+    publishMetadataMap: Map<string, string>
+) => {
+    articles.forEach(article => {
+        if (article.original_publish_date == null) {
+            const original_publish_date = publishMetadataMap.get(
+                article.calculated_slug
+            );
+            if (original_publish_date) {
+                article.original_publish_date = original_publish_date;
+            }
+        }
+    });
+};
+
+const CS_adjustOriginalPublishDate = async (
+    client: ApolloClient<NormalizedCacheObject>,
+    calculatedSlug: string,
+    articles: CS_ArticleResponse[]
+) => {
+    const variables = { calculatedSlug };
+    const publish_metadata = (await fetchAll(
+        getPublishingMetadataQuery,
+        'publish_metadata',
+        client,
+        variables,
+        'no-cache'
+    )) as CS_PublishMetadataResponse[];
+    if (
+        publish_metadata.length > 0 &&
+        articles.length > 0 &&
+        articles[0].original_publish_date == null
+    ) {
+        articles[0].original_publish_date =
+            publish_metadata[0].system.publish_details.time;
+    }
 };
 
 export const CS_getArticleBySlugFromCMS = async (
@@ -26,7 +70,7 @@ export const CS_getArticleBySlugFromCMS = async (
         client,
         variables
     )) as CS_ArticleResponse[];
-
+    await CS_adjustOriginalPublishDate(client, calculatedSlug, articles);
     return articles[0];
 };
 
@@ -42,6 +86,6 @@ export const CS_getDraftArticleBySlugFromCMS = async (
         variables,
         'no-cache'
     )) as CS_ArticleResponse[];
-
+    await CS_adjustOriginalPublishDate(client, calculatedSlug, articles);
     return articles[0];
 };

--- a/src/api-requests/get-publish-metadata.ts
+++ b/src/api-requests/get-publish-metadata.ts
@@ -1,0 +1,27 @@
+import { fetchAll, getClient } from './contentstack_utils';
+import { getAllPublishingMetadataQuery } from '../graphql/publish-metdata';
+import { CS_PublishMetadataResponse } from '../interfaces/publish-metadata';
+
+export const getPublishMetadata = async () => {
+    const client = getClient('production');
+    let publishMetadata: CS_PublishMetadataResponse[] = [];
+    publishMetadata = (await fetchAll(
+        getAllPublishingMetadataQuery,
+        'publish_metadata',
+        client
+    )) as CS_PublishMetadataResponse[];
+    return publishMetadata;
+};
+
+export const getPublishMetadataAsMap = async () => {
+    const publishMetadata = await getPublishMetadata();
+    const metadataMap = new Map<string, string>();
+    publishMetadata.forEach(m => {
+        const publishTime = m.system.publish_details.time;
+        const article = m.articleConnection?.edges[0];
+        if (article) {
+            metadataMap.set(article.node.calculated_slug, publishTime);
+        }
+    });
+    return metadataMap;
+};

--- a/src/graphql/publish-metdata.ts
+++ b/src/graphql/publish-metdata.ts
@@ -1,0 +1,49 @@
+import { gql } from '@apollo/client';
+import { CS_GRAPHQL_LIMIT } from '../data/constants';
+
+export const getAllPublishingMetadataQuery = gql`
+    query get_all_publish_metadata($skip: Int = 0) {
+        publish_metadata: all_publish_metadata(
+            limit: ${CS_GRAPHQL_LIMIT},
+            skip: $skip
+        ) {
+            total
+            items {
+                system {
+                    publish_details {
+                        time
+                    }
+                }
+                articleConnection {
+                    edges {
+                        node {
+                        ... on Articles {
+                                calculated_slug
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`;
+
+export const getPublishingMetadataQuery = gql`
+    query get_all_publish_metadata($skip: Int = 0, $calculatedSlug: String!) {
+        publish_metadata: all_publish_metadata(
+            skip: $skip
+            where: {
+                article: { articles: { calculated_slug: $calculatedSlug } }
+            }
+        ) {
+            total
+            items {
+                system {
+                    publish_details {
+                        time
+                    }
+                }
+            }
+        }
+    }
+`;

--- a/src/interfaces/meta-info.ts
+++ b/src/interfaces/meta-info.ts
@@ -54,7 +54,8 @@ export type ContentTypeUID =
     | 'featured_content'
     | 'featured_content_for_topic'
     | 'podcasts'
-    | 'videos';
+    | 'videos'
+    | 'publish_metadata';
 
 export const contentTypeUIDtoTagType = new Map<ContentTypeUID, TagType>([
     ['l1_products', 'L1Product'],

--- a/src/interfaces/publish-metadata.ts
+++ b/src/interfaces/publish-metadata.ts
@@ -1,0 +1,7 @@
+interface ArticlesConnection {
+    edges: { node: { calculated_slug: string } }[];
+}
+export interface CS_PublishMetadataResponse {
+    articleConnection?: ArticlesConnection;
+    system: { publish_details: { time: string } };
+}


### PR DESCRIPTION
pulling original publish date from publish metadata collection
https://jira.mongodb.org/browse/DEVHUB-1938

Backend PR : https://github.com/10gen/devcenter-backend/pull/127

A new collection "Publish Metadata" is created in contentstack which will store the publish date of the article when published from "ContentStack". There is a realm webhook to create metadata entry upon publishing  which needs to be migrated later as captured in https://jira.mongodb.org/browse/DEVHUB-1938